### PR TITLE
chore: apply prettier to all supported file types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,6 @@ module.exports = {
     project: './tsconfig.eslint.json',
   },
   rules: {
-    'no-console': ['error', { allow: ['none'] }]
-  }
+    'no-console': ['error', { allow: ['none'] }],
+  },
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+package.json

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ When updating nodes without overrides, there is no check to avoid sending the up
 
 ### Update RTDB
 
-This is done automatically during CICD; you should *not* need to run this locally.
+This is done automatically during CICD; you should _not_ need to run this locally.
 
 ```
 yarn update --project={mainnet|alfajores} --database-url={URL to Firebase RTDB location}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,19 +1,13 @@
 module.exports = {
-  "watchman": false,
-  "moduleFileExtensions": [
-    "ts",
-    "js",
-    "json"
-  ],
-  "transform": {
-    "^.+\\.(ts)$": "ts-jest"
+  watchman: false,
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  transform: {
+    '^.+\\.(ts)$': 'ts-jest',
   },
-  "testPathIgnorePatterns": [
-    "dist"
-  ],
-  "globals": {
-    "ts-jest": {
-      "tsconfig": "tsconfig.json"
-    }
-  }
+  testPathIgnorePatterns: ['dist'],
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.json',
+    },
+  },
 }

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   "scripts": {
     "prepare": "husky install",
     "lint": "eslint --ext=.tsx,.ts --fix src/",
-    "format": "prettier --loglevel error --write \"./src/**/*.ts\"",
+    "format": "prettier --loglevel error --write .",
     "validate": "jest",
     "diff": "ts-node scripts/diff.ts",
     "update": "ts-node scripts/update.ts",
-    "test": "yarn jest && yarn prettier --check \"./src/**/*.ts\" && yarn eslint --ext=.ts src/"
+    "test": "yarn jest && yarn prettier --check . && yarn eslint --ext=.ts src/"
   },
   "prettier": "@valora/prettier-config",
   "repository": "git@github.com:valora-inc/rtdb-data.git",

--- a/scripts/diff.ts
+++ b/scripts/diff.ts
@@ -11,7 +11,7 @@ async function main() {
 
   console.log(`Calculating diffs for the ${config.project} GCP project...`)
   let hasDiff = false
-  for (const {data, rtdbLocation} of projectMetadata) {
+  for (const { data, rtdbLocation } of projectMetadata) {
     const rtdbData = await firebaseClient.readFromPath(rtdbLocation)
     const diff = diffString(rtdbData, data)
 

--- a/scripts/update.ts
+++ b/scripts/update.ts
@@ -11,10 +11,12 @@ async function main() {
   const projectMetadata = allMetadata[config.project]
 
   console.log(`Updating RTDB data for the ${config.project} GCP project...`)
-  for (const {data, schema, rtdbLocation, overrideType} of projectMetadata) {
+  for (const { data, schema, rtdbLocation, overrideType } of projectMetadata) {
     const validationResult = schema.validate(data)
     if (validationResult.error) {
-      console.log(`Error while validating schema for ${rtdbLocation}, skipping: ${validationResult.error}`)
+      console.log(
+        `Error while validating schema for ${rtdbLocation}, skipping: ${validationResult.error}`,
+      )
     } else {
       const rtdbData = await firebaseClient.readFromPath(rtdbLocation)
       const diff = diffString(rtdbData, data)
@@ -27,7 +29,10 @@ async function main() {
         } else {
           let updateRequest = data
           if (overrideType.deleteMissingKeys) {
-            const deleteMissingKeys = deleteMissingKeysUpdateRequest(data, rtdbData)
+            const deleteMissingKeys = deleteMissingKeysUpdateRequest(
+              data,
+              rtdbData,
+            )
             updateRequest = { ...updateRequest, ...deleteMissingKeys }
           }
           // TODO: Avoid updating the node if we already know there aren't changes
@@ -40,7 +45,7 @@ async function main() {
 }
 
 main()
-  .then(() => (process.exit(0)))
+  .then(() => process.exit(0))
   .catch((error) => {
     console.log(`Error while updating RTDB data: ${error}`)
     process.exit(1)

--- a/src/data/alfajores/addresses-extra-info.json
+++ b/src/data/alfajores/addresses-extra-info.json
@@ -1,39 +1,39 @@
 {
-  "0x20d5ca2a263e0c0d11e7a668ccf30b38f148225b" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media",
-    "name" : "Gonza Test Address"
+  "0x20d5ca2a263e0c0d11e7a668ccf30b38f148225b": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media",
+    "name": "Gonza Test Address"
   },
-  "0x22579ca45ee22e2e16ddf72d955d6cf4c767b0ef" : {
-    "name" : "Funds Granted by Faucet"
+  "0x22579ca45ee22e2e16ddf72d955d6cf4c767b0ef": {
+    "name": "Funds Granted by Faucet"
   },
-  "0x4b371df8d05abd2954564b54faf10b8c8f1bc3a2" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media",
-    "name" : "Hello!"
+  "0x4b371df8d05abd2954564b54faf10b8c8f1bc3a2": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media",
+    "name": "Hello!"
   },
-  "0x4f34051b728c93dd39531ed44a52c7f5f6fa7d81" : {
-    "name" : "Celo Test Address"
+  "0x4f34051b728c93dd39531ed44a52c7f5f6fa7d81": {
+    "name": "Celo Test Address"
   },
-  "0xa4e5079f1cb893d18bdd76a082bd098b29980094" : {
-    "name" : "qwe"
+  "0xa4e5079f1cb893d18bdd76a082bd098b29980094": {
+    "name": "qwe"
   },
-  "0xb04390478a57e3c2147599d5380434f25fa5234d" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "name" : "CELO Network"
+  "0xb04390478a57e3c2147599d5380434f25fa5234d": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "name": "CELO Network"
   },
-  "0xb251f93b5ec2e932249c39d713c49945b1f4515b" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Network"
+  "0xb251f93b5ec2e932249c39d713c49945b1f4515b": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Network"
   },
-  "0xd9fff7058083b7f9ff8d1eb6cd8723ac269421a4" : {
-    "name" : "Diego Test Wallet 3"
+  "0xd9fff7058083b7f9ff8d1eb6cd8723ac269421a4": {
+    "name": "Diego Test Wallet 3"
   },
-  "0xe3e32f52f35e883458479631ae7fed7498d6553f" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media",
-    "name" : "CELO Network"
+  "0xe3e32f52f35e883458479631ae7fed7498d6553f": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media",
+    "name": "CELO Network"
   },
-  "0xeefd851e7f742b805311501706c1192959754b11" : {
-    "imageUrl" : "https://source.unsplash.com/user/c_v_r/150x150",
-    "name" : "Diego Test Wallet 1"
+  "0xeefd851e7f742b805311501706c1192959754b11": {
+    "imageUrl": "https://source.unsplash.com/user/c_v_r/150x150",
+    "name": "Diego Test Wallet 1"
   }
 }

--- a/src/data/alfajores/tokens-info.json
+++ b/src/data/alfajores/tokens-info.json
@@ -1,205 +1,205 @@
 {
-  "0x00be915b9dcf56a3cbe739d9b9c202ca692409ec" : {
-    "address" : "0x00be915b9dcf56a3cbe739d9b9c202ca692409ec",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_UBE.png",
-    "name" : "Ubeswap",
-    "symbol" : "UBE"
+  "0x00be915b9dcf56a3cbe739d9b9c202ca692409ec": {
+    "address": "0x00be915b9dcf56a3cbe739d9b9c202ca692409ec",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_UBE.png",
+    "name": "Ubeswap",
+    "symbol": "UBE"
   },
-  "0x048f47d358ec521a6cf384461d674750a3cb58c8" : {
-    "address" : "0x048f47d358ec521a6cf384461d674750a3cb58c8",
-    "decimals" : 10,
-    "imageUrl" : "https://diquecito.com.ar/wp-content/uploads/2018/08/test.jpeg",
-    "name" : "Test Token",
-    "symbol" : "TT"
+  "0x048f47d358ec521a6cf384461d674750a3cb58c8": {
+    "address": "0x048f47d358ec521a6cf384461d674750a3cb58c8",
+    "decimals": 10,
+    "imageUrl": "https://diquecito.com.ar/wp-content/uploads/2018/08/test.jpeg",
+    "name": "Test Token",
+    "symbol": "TT"
   },
-  "0x10c892a6ec43a53e45d0b916b4b7d383b1b78c0f" : {
-    "address" : "0x10c892a6ec43a53e45d0b916b4b7d383b1b78c0f",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cEUR.png",
-    "isCoreToken" : true,
-    "name" : "Celo Euro",
-    "symbol" : "cEUR"
+  "0x10c892a6ec43a53e45d0b916b4b7d383b1b78c0f": {
+    "address": "0x10c892a6ec43a53e45d0b916b4b7d383b1b78c0f",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cEUR.png",
+    "isCoreToken": true,
+    "name": "Celo Euro",
+    "symbol": "cEUR"
   },
-  "0x123ed050805e0998ebef43671327139224218e50" : {
-    "address" : "0x123ed050805e0998ebef43671327139224218e50",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_NTMX.png",
-    "name" : "NetM Token",
-    "symbol" : "NTMX"
+  "0x123ed050805e0998ebef43671327139224218e50": {
+    "address": "0x123ed050805e0998ebef43671327139224218e50",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_NTMX.png",
+    "name": "NetM Token",
+    "symbol": "NTMX"
   },
-  "0x14f6392a624e1fcd651c688582a3051157635510" : {
-    "address" : "0x14f6392a624e1fcd651c688582a3051157635510",
-    "decimals" : 18,
-    "name" : "Ubeswap Governance Token",
-    "symbol" : "UBE"
+  "0x14f6392a624e1fcd651c688582a3051157635510": {
+    "address": "0x14f6392a624e1fcd651c688582a3051157635510",
+    "decimals": 18,
+    "name": "Ubeswap Governance Token",
+    "symbol": "UBE"
   },
-  "0x22fdf8332a8afd169d90606f4bc9cbf6ce452da4" : {
-    "address" : "0x22fdf8332a8afd169d90606f4bc9cbf6ce452da4",
-    "decimals" : 18,
-    "name" : "Farmbot FP Token",
-    "symbol" : "cEUR_CELO_FP"
+  "0x22fdf8332a8afd169d90606f4bc9cbf6ce452da4": {
+    "address": "0x22fdf8332a8afd169d90606f4bc9cbf6ce452da4",
+    "decimals": 18,
+    "name": "Farmbot FP Token",
+    "symbol": "cEUR_CELO_FP"
   },
-  "0x2def4285787d58a2f811af24755a8150622f4361" : {
-    "address" : "0x2def4285787d58a2f811af24755a8150622f4361",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cETH.svg",
-    "name" : "Wrapped Ethereum",
-    "symbol" : "cETH"
+  "0x2def4285787d58a2f811af24755a8150622f4361": {
+    "address": "0x2def4285787d58a2f811af24755a8150622f4361",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cETH.svg",
+    "name": "Wrapped Ethereum",
+    "symbol": "cETH"
   },
-  "0x32974c7335e649932b5766c5ae15595afc269160" : {
-    "address" : "0x32974c7335e649932b5766c5ae15595afc269160",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mcEURxOLD.png",
-    "name" : "Moola cEUR MToken",
-    "symbol" : "mCEUR",
-    "pegTo" : "0x10c892a6ec43a53e45d0b916b4b7d383b1b78c0f"
+  "0x32974c7335e649932b5766c5ae15595afc269160": {
+    "address": "0x32974c7335e649932b5766c5ae15595afc269160",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mcEURxOLD.png",
+    "name": "Moola cEUR MToken",
+    "symbol": "mCEUR",
+    "pegTo": "0x10c892a6ec43a53e45d0b916b4b7d383b1b78c0f"
   },
-  "0x452ef5a4bd00796e62e5e5758548e0da6e8ccdf3" : {
-    "address" : "0x452ef5a4bd00796e62e5e5758548e0da6e8ccdf3",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cStar.png",
-    "name" : "TestToken",
-    "symbol" : "TT"
+  "0x452ef5a4bd00796e62e5e5758548e0da6e8ccdf3": {
+    "address": "0x452ef5a4bd00796e62e5e5758548e0da6e8ccdf3",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cStar.png",
+    "name": "TestToken",
+    "symbol": "TT"
   },
-  "0x4b38e05a3c70038bf353603eb59436a8f93f128f" : {
-    "address" : "0x4b38e05a3c70038bf353603eb59436a8f93f128f",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cStar.png",
-    "name" : "Valora Token",
-    "symbol" : "VT"
+  "0x4b38e05a3c70038bf353603eb59436a8f93f128f": {
+    "address": "0x4b38e05a3c70038bf353603eb59436a8f93f128f",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cStar.png",
+    "name": "Valora Token",
+    "symbol": "VT"
   },
-  "0x4bbf3bd45128195111f6e93035e3f199ba376f3b" : {
-    "address" : "0x4bbf3bd45128195111f6e93035e3f199ba376f3b",
-    "decimals" : 18,
-    "name" : "Moola Governance Token",
-    "symbol" : "MOO"
+  "0x4bbf3bd45128195111f6e93035e3f199ba376f3b": {
+    "address": "0x4bbf3bd45128195111f6e93035e3f199ba376f3b",
+    "decimals": 18,
+    "name": "Moola Governance Token",
+    "symbol": "MOO"
   },
-  "0x51238067d3154b4c866cf08b3db6cabc9200e6c0" : {
-    "address" : "0x51238067d3154b4c866cf08b3db6cabc9200e6c0",
-    "decimals" : 18,
-    "name" : "cPad Token Testnet",
-    "symbol" : "T-cPad"
+  "0x51238067d3154b4c866cf08b3db6cabc9200e6c0": {
+    "address": "0x51238067d3154b4c866cf08b3db6cabc9200e6c0",
+    "decimals": 18,
+    "name": "cPad Token Testnet",
+    "symbol": "T-cPad"
   },
-  "0x51ae41dafeec6ca0858a8af2ee4ba31cdd89b4d4" : {
-    "address" : "0x51ae41dafeec6ca0858a8af2ee4ba31cdd89b4d4",
-    "decimals" : 18,
-    "name" : "Celo Helpi",
-    "symbol" : "cHLP"
+  "0x51ae41dafeec6ca0858a8af2ee4ba31cdd89b4d4": {
+    "address": "0x51ae41dafeec6ca0858a8af2ee4ba31cdd89b4d4",
+    "decimals": 18,
+    "name": "Celo Helpi",
+    "symbol": "cHLP"
   },
-  "0x71db38719f9113a36e14f409bad4f07b58b4730b" : {
-    "address" : "0x71db38719f9113a36e14f409bad4f07b58b4730b",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mcUSDxOLD.png",
-    "name" : "Moola cUSD AToken",
-    "symbol" : "mCUSD",
-    "pegTo" : "0x874069fa1eb16d44d622f2e0ca25eea172369bc1"
+  "0x71db38719f9113a36e14f409bad4f07b58b4730b": {
+    "address": "0x71db38719f9113a36e14f409bad4f07b58b4730b",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mcUSDxOLD.png",
+    "name": "Moola cUSD AToken",
+    "symbol": "mCUSD",
+    "pegTo": "0x874069fa1eb16d44d622f2e0ca25eea172369bc1"
   },
-  "0x86f61eb83e10e914fc6f321f5dd3c2dd4860a003" : {
-    "address" : "0x86f61eb83e10e914fc6f321f5dd3c2dd4860a003",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mCELOxOLD.png",
-    "name" : "Moola CELO AToken",
-    "symbol" : "mCELO",
-    "pegTo" : "0xf194afdf50b03e69bd7d057c1aa9e10c9954e4c9"
+  "0x86f61eb83e10e914fc6f321f5dd3c2dd4860a003": {
+    "address": "0x86f61eb83e10e914fc6f321f5dd3c2dd4860a003",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mCELOxOLD.png",
+    "name": "Moola CELO AToken",
+    "symbol": "mCELO",
+    "pegTo": "0xf194afdf50b03e69bd7d057c1aa9e10c9954e4c9"
   },
-  "0x874069fa1eb16d44d622f2e0ca25eea172369bc1" : {
-    "address" : "0x874069fa1eb16d44d622f2e0ca25eea172369bc1",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cUSD.png",
-    "isCoreToken" : true,
-    "name" : "Celo Dollar",
-    "symbol" : "cUSD"
+  "0x874069fa1eb16d44d622f2e0ca25eea172369bc1": {
+    "address": "0x874069fa1eb16d44d622f2e0ca25eea172369bc1",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cUSD.png",
+    "isCoreToken": true,
+    "name": "Celo Dollar",
+    "symbol": "cUSD"
   },
-  "0x8d0b8633c6c3d5c1eafb767b3eaf0723e49c9c98" : {
-    "address" : "0x8d0b8633c6c3d5c1eafb767b3eaf0723e49c9c98",
-    "decimals" : 18,
-    "name" : "mCle",
-    "symbol" : "t-Cle"
+  "0x8d0b8633c6c3d5c1eafb767b3eaf0723e49c9c98": {
+    "address": "0x8d0b8633c6c3d5c1eafb767b3eaf0723e49c9c98",
+    "decimals": 18,
+    "name": "mCle",
+    "symbol": "t-Cle"
   },
-  "0x95b08d622d3601a70a60d4233dd874475bb0217d" : {
-    "address" : "0x95b08d622d3601a70a60d4233dd874475bb0217d",
-    "decimals" : 18,
-    "name" : "CeloMinum",
-    "symbol" : "CLM"
+  "0x95b08d622d3601a70a60d4233dd874475bb0217d": {
+    "address": "0x95b08d622d3601a70a60d4233dd874475bb0217d",
+    "decimals": 18,
+    "name": "CeloMinum",
+    "symbol": "CLM"
   },
-  "0x980a2a0833defbd33912bd102ed41421c919861b" : {
-    "address" : "0x980a2a0833defbd33912bd102ed41421c919861b",
-    "decimals" : 18,
-    "name" : "TestMasa",
-    "symbol" : "tCORN"
+  "0x980a2a0833defbd33912bd102ed41421c919861b": {
+    "address": "0x980a2a0833defbd33912bd102ed41421c919861b",
+    "decimals": 18,
+    "name": "TestMasa",
+    "symbol": "tCORN"
   },
-  "0x9b8118001677e47368c8d08032a40fb64a956938" : {
-    "address" : "0x9b8118001677e47368c8d08032a40fb64a956938",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/valora-inc/valora-token/main/assets/puppy_coin_icon.png?token=AB44BT5L3BUR2KB6GG4UMYDBXPJJU",
-    "name" : "Puppy-themed Valora token",
-    "symbol" : "PUP"
+  "0x9b8118001677e47368c8d08032a40fb64a956938": {
+    "address": "0x9b8118001677e47368c8d08032a40fb64a956938",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/valora-inc/valora-token/main/assets/puppy_coin_icon.png?token=AB44BT5L3BUR2KB6GG4UMYDBXPJJU",
+    "name": "Puppy-themed Valora token",
+    "symbol": "PUP"
   },
-  "0x9f74871d69448674b4cf620b07e57360f949c018" : {
-    "address" : "0x9f74871d69448674b4cf620b07e57360f949c018",
-    "decimals" : 18,
-    "name" : "mCle",
-    "symbol" : "t-Cle"
+  "0x9f74871d69448674b4cf620b07e57360f949c018": {
+    "address": "0x9f74871d69448674b4cf620b07e57360f949c018",
+    "decimals": 18,
+    "name": "mCle",
+    "symbol": "t-Cle"
   },
-  "0xa753f5ff860c142b1c225ababb629e7bc572ffed" : {
-    "address" : "0xa753f5ff860c142b1c225ababb629e7bc572ffed",
-    "decimals" : 18,
-    "name" : "cVerse",
-    "symbol" : "cVRS"
+  "0xa753f5ff860c142b1c225ababb629e7bc572ffed": {
+    "address": "0xa753f5ff860c142b1c225ababb629e7bc572ffed",
+    "decimals": 18,
+    "name": "cVerse",
+    "symbol": "cVRS"
   },
-  "0xa9947051aa9243d72f8f5578d3bfb992b20ad97d" : {
-    "address" : "0xa9947051aa9243d72f8f5578d3bfb992b20ad97d",
-    "decimals" : 18,
-    "name" : "Farmbot FP Token",
-    "symbol" : "cUSD_CELO_FP"
+  "0xa9947051aa9243d72f8f5578d3bfb992b20ad97d": {
+    "address": "0xa9947051aa9243d72f8f5578d3bfb992b20ad97d",
+    "decimals": 18,
+    "name": "Farmbot FP Token",
+    "symbol": "cUSD_CELO_FP"
   },
-  "0xb22e6912d4c4d94bde533399ed56cb5a53b024ef" : {
-    "address" : "0xb22e6912d4c4d94bde533399ed56cb5a53b024ef",
-    "decimals" : 18,
-    "name" : "ELTToken",
-    "symbol" : "ELT"
+  "0xb22e6912d4c4d94bde533399ed56cb5a53b024ef": {
+    "address": "0xb22e6912d4c4d94bde533399ed56cb5a53b024ef",
+    "decimals": 18,
+    "name": "ELTToken",
+    "symbol": "ELT"
   },
-  "0xc6363c8ae41b2d32fd48739a7fc35f4d0278fe4f" : {
-    "address" : "0xc6363c8ae41b2d32fd48739a7fc35f4d0278fe4f",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/valora-inc/valora-token/main/assets/kitty_coin_icon.png?token=AB44BT7UD2C56IAGAGWP453BXPJHO",
-    "name" : "Kitty-themed Valora token",
-    "symbol" : "KITTY"
+  "0xc6363c8ae41b2d32fd48739a7fc35f4d0278fe4f": {
+    "address": "0xc6363c8ae41b2d32fd48739a7fc35f4d0278fe4f",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/valora-inc/valora-token/main/assets/kitty_coin_icon.png?token=AB44BT7UD2C56IAGAGWP453BXPJHO",
+    "name": "Kitty-themed Valora token",
+    "symbol": "KITTY"
   },
-  "0xc63c3243601e038286a82c0f97f47bf20f2f1b82" : {
-    "address" : "0xc63c3243601e038286a82c0f97f47bf20f2f1b82",
-    "decimals" : 18,
-    "name" : "mCle",
-    "symbol" : "tCle"
+  "0xc63c3243601e038286a82c0f97f47bf20f2f1b82": {
+    "address": "0xc63c3243601e038286a82c0f97f47bf20f2f1b82",
+    "decimals": 18,
+    "name": "mCle",
+    "symbol": "tCle"
   },
-  "0xd9886768c897257a48572d3cfc2e15140acea3fb" : {
-    "address" : "0xd9886768c897257a48572d3cfc2e15140acea3fb",
-    "decimals" : 18,
-    "name" : "T-celoLaunch",
-    "symbol" : "T-cLA"
+  "0xd9886768c897257a48572d3cfc2e15140acea3fb": {
+    "address": "0xd9886768c897257a48572d3cfc2e15140acea3fb",
+    "decimals": 18,
+    "name": "T-celoLaunch",
+    "symbol": "T-cLA"
   },
-  "0xe4d517785d091d3c54818832db6094bcc2744545" : {
-    "address" : "0xe4d517785d091d3c54818832db6094bcc2744545",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cREAL.png",
-    "isCoreToken" : true,
-    "name" : "Celo Real",
-    "symbol" : "cREAL"
+  "0xe4d517785d091d3c54818832db6094bcc2744545": {
+    "address": "0xe4d517785d091d3c54818832db6094bcc2744545",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cREAL.png",
+    "isCoreToken": true,
+    "name": "Celo Real",
+    "symbol": "cREAL"
   },
-  "0xf194afdf50b03e69bd7d057c1aa9e10c9954e4c9" : {
-    "address" : "0xf194afdf50b03e69bd7d057c1aa9e10c9954e4c9",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_CELO.png",
-    "isCoreToken" : true,
-    "name" : "Celo native asset",
-    "symbol" : "CELO"
+  "0xf194afdf50b03e69bd7d057c1aa9e10c9954e4c9": {
+    "address": "0xf194afdf50b03e69bd7d057c1aa9e10c9954e4c9",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_CELO.png",
+    "isCoreToken": true,
+    "name": "Celo native asset",
+    "symbol": "CELO"
   },
-  "0xfe63c2141258ad2a10968d808751aa605ba394fc" : {
-    "address" : "0xfe63c2141258ad2a10968d808751aa605ba394fc",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/valora-inc/valora-token/main/assets/boring_coin_icon.png?token=AB44BTZV3DFF5X2MTT2PSVTBXPJCS",
-    "name" : "Boring Valora token",
-    "symbol" : "BORING"
+  "0xfe63c2141258ad2a10968d808751aa605ba394fc": {
+    "address": "0xfe63c2141258ad2a10968d808751aa605ba394fc",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/valora-inc/valora-token/main/assets/boring_coin_icon.png?token=AB44BTZV3DFF5X2MTT2PSVTBXPJCS",
+    "name": "Boring Valora token",
+    "symbol": "BORING"
   }
 }

--- a/src/data/mainnet/addresses-extra-info.json
+++ b/src/data/mainnet/addresses-extra-info.json
@@ -1,238 +1,238 @@
 {
-  "0x10032e2559b019be263e787a5a50a5eeb70b6e24" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fokcoin.png?alt=media&token=39d6d12a-3b4c-4f51-9aec-ba2258bdac2a",
-    "name" : "OKCoin"
+  "0x10032e2559b019be263e787a5a50a5eeb70b6e24": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fokcoin.png?alt=media&token=39d6d12a-3b4c-4f51-9aec-ba2258bdac2a",
+    "name": "OKCoin"
   },
-  "0x108d7a69a91f60cdb1aae429c47bc13ae5fefd24" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0x108d7a69a91f60cdb1aae429c47bc13ae5fefd24": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0x1776e2abc32b54a2818119979c70a465d18e46f5" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : false,
-    "name" : "CELO Network"
+  "0x1776e2abc32b54a2818119979c70a465d18e46f5": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": false,
+    "name": "CELO Network"
   },
   "0x185318be22136f2ec07edcb6fb2d65e45d06fc48": {
     "name": "CC2022 Merchant Payment",
     "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2FCC2022ICON.png?alt=media"
   },
-  "0x198e0d8601ab509abf1b0b99fd8f234583ef1309" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media",
-    "name" : "CELO Network"
+  "0x198e0d8601ab509abf1b0b99fd8f234583ef1309": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media",
+    "name": "CELO Network"
   },
-  "0x1a0e08d4bc0edb05036ce81d6b21278b5381c680" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0x1a0e08d4bc0edb05036ce81d6b21278b5381c680": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0x26d3d450f9118170e81896e5e4d996d8e37b03e0" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media",
-    "isCeloRewardSender" : false,
-    "name" : "CELO Network"
+  "0x26d3d450f9118170e81896e5e4d996d8e37b03e0": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media",
+    "isCeloRewardSender": false,
+    "name": "CELO Network"
   },
-  "0x3066505c7d215161b4a8377818bad04f33bca6f7" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fdeposit.png?alt=media",
-    "isProviderAddress" : false,
-    "name" : "Deposit"
+  "0x3066505c7d215161b4a8377818bad04f33bca6f7": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fdeposit.png?alt=media",
+    "isProviderAddress": false,
+    "name": "Deposit"
   },
-  "0x3181149dd2adb0dfd3593e4aaa382813fbe09df7" : {
-    "name" : "DeFi Competition"
+  "0x3181149dd2adb0dfd3593e4aaa382813fbe09df7": {
+    "name": "DeFi Competition"
   },
-  "0x32d15e2e9112302265a26d7e7ac83edc6e64ec4c" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0x32d15e2e9112302265a26d7e7ac83edc6e64ec4c": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0x370b0470a43b931cebf6935c1cce6dcbfdc8e0dc" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : false,
-    "name" : "CELO Network"
+  "0x370b0470a43b931cebf6935c1cce6dcbfdc8e0dc": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": false,
+    "name": "CELO Network"
   },
-  "0x406aa797d88807ea9a02eaa6a37e0b20c0223272" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0x406aa797d88807ea9a02eaa6a37e0b20c0223272": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0x44aa75d94b70aaf2ffcea9d61081f2be86dc8536" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0x44aa75d94b70aaf2ffcea9d61081f2be86dc8536": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0x47b9b9b88ccbcf580472c8e17184be073b0e3a83" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0x47b9b9b88ccbcf580472c8e17184be073b0e3a83": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0x56d31ac7bacbcb3e8de14beeb1e6c89390ab5216" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0x56d31ac7bacbcb3e8de14beeb1e6c89390ab5216": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0x572ff3ed7217616e8dee6ea72a065c17c5d62a7f" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2FCeloTax.jpeg?alt=media",
-    "name" : "Celo Tax"
+  "0x572ff3ed7217616e8dee6ea72a065c17c5d62a7f": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2FCeloTax.jpeg?alt=media",
+    "name": "Celo Tax"
   },
-  "0x57c46e439ae70cd15234f171aa8afc535f0f50c3" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media",
-    "isCeloRewardSender" : false,
-    "name" : "CELO Network"
+  "0x57c46e439ae70cd15234f171aa8afc535f0f50c3": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media",
+    "isCeloRewardSender": false,
+    "name": "CELO Network"
   },
-  "0x5bc2e7394fbd1074eacb78923802952def4ba8c2" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0x5bc2e7394fbd1074eacb78923802952def4ba8c2": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0x5c8c4e3d8657e9d3a976233fd0ba647f262dce3a" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : false,
-    "name" : "CELO Network"
+  "0x5c8c4e3d8657e9d3a976233fd0ba647f262dce3a": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": false,
+    "name": "CELO Network"
   },
-  "0x6cc083aed9e3ebe302a6336dbc7c921c9f03349e" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media",
-    "name" : "Locked CELO"
+  "0x6cc083aed9e3ebe302a6336dbc7c921c9f03349e": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media",
+    "name": "Locked CELO"
   },
-  "0x6f634f531ed0043b94527f68ec7861b4b1ab110d" : {
-    "imageUrl" : "https://dl.airtable.com/.attachmentThumbnails/1ac7c5cf31c5b0e677d1655b0c6fda2c/141a41ed",
-    "name" : "PoolTogether"
+  "0x6f634f531ed0043b94527f68ec7861b4b1ab110d": {
+    "imageUrl": "https://dl.airtable.com/.attachmentThumbnails/1ac7c5cf31c5b0e677d1655b0c6fda2c/141a41ed",
+    "name": "PoolTogether"
   },
-  "0x71adee1b7ac4756df017473e6bee668b59b503e7" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0x71adee1b7ac4756df017473e6bee668b59b503e7": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0x72596f55b8d88806c39de15a956b48f1a004292c" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : false,
-    "name" : "CELO Network"
+  "0x72596f55b8d88806c39de15a956b48f1a004292c": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": false,
+    "name": "CELO Network"
   },
-  "0x75498d5471ca24779af601371e958845b0b2df00" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0x75498d5471ca24779af601371e958845b0b2df00": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0x786a381dffe54f97483804a3fb74d46c5b562812" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0x786a381dffe54f97483804a3fb74d46c5b562812": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0x7a6ac258691a678719787d21265c8712e73948eb" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : false,
-    "name" : "CELO Network"
+  "0x7a6ac258691a678719787d21265c8712e73948eb": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": false,
+    "name": "CELO Network"
   },
-  "0x7f501701024490714354d8d99014c465d991b407" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0x7f501701024490714354d8d99014c465d991b407": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
   "0x8130314f4aa56a89f42faeaa69e7bfa04456ccec": {
     "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsupercharge_logo.png?alt=media",
     "name": "Supercharge"
   },
-  "0x8af1400045e713d2f833ec6d1d76c2f0ea675418" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0x8af1400045e713d2f833ec6d1d76c2f0ea675418": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0x8af9561dc8b09f29579ed3e55697c7f784fcb1d9" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0x8af9561dc8b09f29579ed3e55697c7f784fcb1d9": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0x98db3a41bf8bf4ded2c92a84ec0705689ddeef8b" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fdeposit.png?alt=media",
-    "name" : "Deposit"
+  "0x98db3a41bf8bf4ded2c92a84ec0705689ddeef8b": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fdeposit.png?alt=media",
+    "name": "Deposit"
   },
-  "0x9bce69a441ff5c4a1391385b45cb36737d735874" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0x9bce69a441ff5c4a1391385b45cb36737d735874": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0x9be36dcc1ccebf6e926db0ae46996c59548ca190" : {
-    "imageUrl" : "https://valoraapp.com/_next/static/images/icon-62b90ddabe4910b9c5d55ecabf817aa8.png",
-    "name" : "DeFi Competition"
+  "0x9be36dcc1ccebf6e926db0ae46996c59548ca190": {
+    "imageUrl": "https://valoraapp.com/_next/static/images/icon-62b90ddabe4910b9c5d55ecabf817aa8.png",
+    "name": "DeFi Competition"
   },
-  "0x99300109cd3bccc0ee1c535b9bb0b5f4a6a2adb4" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Funchained.jpeg?alt=media",
-    "name" : "Unchain"
+  "0x99300109cd3bccc0ee1c535b9bb0b5f4a6a2adb4": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Funchained.jpeg?alt=media",
+    "name": "Unchain"
   },
-  "0xa203bbf51a5bc4a8a82f8e145d01d0333471d411" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fdeposit.png?alt=media",
-    "name" : "Deposit"
+  "0xa203bbf51a5bc4a8a82f8e145d01d0333471d411": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fdeposit.png?alt=media",
+    "name": "Deposit"
   },
-  "0xac7dc6ff8cc08b6a4ad5d86cd5d2922d0c9014e9" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : false,
-    "name" : "CELO Network"
+  "0xac7dc6ff8cc08b6a4ad5d86cd5d2922d0c9014e9": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": false,
+    "name": "CELO Network"
   },
-  "0xaf106f8d4756490e7069027315f4886cc94a8f73" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fmoola.jpeg?alt=media",
-    "name" : "Moola Market"
+  "0xaf106f8d4756490e7069027315f4886cc94a8f73": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fmoola.jpeg?alt=media",
+    "name": "Moola Market"
   },
-  "0xb07535cc39af3f1baf98e3c723ac1e8265ab614f" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fdeposit.png?alt=media",
-    "name" : "Deposit"
+  "0xb07535cc39af3f1baf98e3c723ac1e8265ab614f": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fdeposit.png?alt=media",
+    "name": "Deposit"
   },
-  "0xb0e53289936169247be347692803c391c21cdabb" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0xb0e53289936169247be347692803c391c21cdabb": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0xb523f7457268965a663919a12fae776093ab8981" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fdeposit.png?alt=media",
-    "isProviderAddress" : false,
-    "name" : "Deposit"
+  "0xb523f7457268965a663919a12fae776093ab8981": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fdeposit.png?alt=media",
+    "isProviderAddress": false,
+    "name": "Deposit"
   },
-  "0xbdd68b64e288171b37f01346042bee6eb7dfae4f" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media",
-    "name" : "CELO Network"
+  "0xbdd68b64e288171b37f01346042bee6eb7dfae4f": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media",
+    "name": "CELO Network"
   },
-  "0xc0b2ab5e740e55ab26678566038c47c60f005340" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0xc0b2ab5e740e55ab26678566038c47c60f005340": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0xcc324f91caebd967c1589741b4baafe27d750456" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : false,
-    "name" : "CELO Network"
+  "0xcc324f91caebd967c1589741b4baafe27d750456": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": false,
+    "name": "CELO Network"
   },
-  "0xd87cb8ceb4ff5100b7e17288b023db4b30324964" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0xd87cb8ceb4ff5100b7e17288b023db4b30324964": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0xdee138b9620ef533ac2cdef28226706ecd083f0b" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : false,
-    "name" : "CELO Network"
+  "0xdee138b9620ef533ac2cdef28226706ecd083f0b": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": false,
+    "name": "CELO Network"
   },
-  "0xef0b9226fc6a5acd320720a2fcec6b31ed2ac862" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0xef0b9226fc6a5acd320720a2fcec6b31ed2ac862": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0xf4390103185d498c6b7830fc527d38eb690a17ea" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : false,
-    "name" : "CELO Network"
+  "0xf4390103185d498c6b7830fc527d38eb690a17ea": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": false,
+    "name": "CELO Network"
   },
   "0xf60d112c55aef2a97fc434c84a5e3d9e91af75f6": {
     "name": "Nomspace",
     "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fnomspace.jpeg?alt=media"
   },
-  "0xfaa7649e51ec69abf7ba21422a433896bbd9c3ca" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0xfaa7649e51ec69abf7ba21422a433896bbd9c3ca": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0xfbbce3c212f7f03bc055156211772bda4f2522dd" : {
-    "imageUrl" : "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
-    "isCeloRewardSender" : true,
-    "name" : "CELO Rewards"
+  "0xfbbce3c212f7f03bc055156211772bda4f2522dd": {
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-alfajores.appspot.com/o/images%2Fcelo.jpg?alt=media&token=fff87029-c779-46d1-b8f5-765cd91ebe0f",
+    "isCeloRewardSender": true,
+    "name": "CELO Rewards"
   },
-  "0x8a37f0290ae85d08522d2a605617e76128fd0712" : {
+  "0x8a37f0290ae85d08522d2a605617e76128fd0712": {
     "name": "Ramp",
     "imageUrl": "https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Framp.png?alt=media"
   }

--- a/src/data/mainnet/tokens-info.json
+++ b/src/data/mainnet/tokens-info.json
@@ -1,240 +1,240 @@
 {
-  "0x00400fcbf0816bebb94654259de7273f4a05c762" : {
-    "address" : "0x00400fcbf0816bebb94654259de7273f4a05c762",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_POOF.png",
-    "name" : "PoofCash",
-    "symbol" : "POOF"
+  "0x00400fcbf0816bebb94654259de7273f4a05c762": {
+    "address": "0x00400fcbf0816bebb94654259de7273f4a05c762",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_POOF.png",
+    "name": "PoofCash",
+    "symbol": "POOF"
   },
-  "0x00be915b9dcf56a3cbe739d9b9c202ca692409ec" : {
-    "address" : "0x00be915b9dcf56a3cbe739d9b9c202ca692409ec",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_UBE.png",
-    "name" : "Ubeswap",
-    "symbol" : "UBE"
+  "0x00be915b9dcf56a3cbe739d9b9c202ca692409ec": {
+    "address": "0x00be915b9dcf56a3cbe739d9b9c202ca692409ec",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_UBE.png",
+    "name": "Ubeswap",
+    "symbol": "UBE"
   },
-  "0x035ee610693a29cb77fd6efbeb9d9d278703e145" : {
-    "address" : "0x035ee610693a29cb77fd6efbeb9d9d278703e145",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_TFBX.png",
-    "name" : "Truefeedback",
-    "symbol" : "TFBX"
+  "0x035ee610693a29cb77fd6efbeb9d9d278703e145": {
+    "address": "0x035ee610693a29cb77fd6efbeb9d9d278703e145",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_TFBX.png",
+    "name": "Truefeedback",
+    "symbol": "TFBX"
   },
-  "0x0a60c25ef6021fc3b479914e6bca7c03c18a97f1" : {
-    "address" : "0x0a60c25ef6021fc3b479914e6bca7c03c18a97f1",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_stabilUSD.png",
-    "name" : "Stabilite USD",
-    "symbol" : "stabilUSD"
+  "0x0a60c25ef6021fc3b479914e6bca7c03c18a97f1": {
+    "address": "0x0a60c25ef6021fc3b479914e6bca7c03c18a97f1",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_stabilUSD.png",
+    "name": "Stabilite USD",
+    "symbol": "stabilUSD"
   },
-  "0x0a7432cf27f1ae3825c313f3c81e7d3efd7639ab" : {
-    "address" : "0x0a7432cf27f1ae3825c313f3c81e7d3efd7639ab",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_CRV.png",
-    "name" : "Curve DAO Token",
-    "symbol" : "CRV"
+  "0x0a7432cf27f1ae3825c313f3c81e7d3efd7639ab": {
+    "address": "0x0a7432cf27f1ae3825c313f3c81e7d3efd7639ab",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_CRV.png",
+    "name": "Curve DAO Token",
+    "symbol": "CRV"
   },
-  "0x122013fd7df1c6f636a5bb8f03108e876548b455" : {
-    "address" : "0x122013fd7df1c6f636a5bb8f03108e876548b455",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_WETH.png",
-    "name" : "Wrapped Ether",
-    "symbol" : "WETH"
+  "0x122013fd7df1c6f636a5bb8f03108e876548b455": {
+    "address": "0x122013fd7df1c6f636a5bb8f03108e876548b455",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_WETH.png",
+    "name": "Wrapped Ether",
+    "symbol": "WETH"
   },
-  "0x173234922eb27d5138c5e481be9df5261faed450" : {
-    "address" : "0x173234922eb27d5138c5e481be9df5261faed450",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_SOL.png",
-    "name" : "SOL",
-    "symbol" : "SOL"
+  "0x173234922eb27d5138c5e481be9df5261faed450": {
+    "address": "0x173234922eb27d5138c5e481be9df5261faed450",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_SOL.png",
+    "name": "SOL",
+    "symbol": "SOL"
   },
-  "0x17700282592d6917f6a73d0bf8accf4d578c131e" : {
-    "address" : "0x17700282592d6917f6a73d0bf8accf4d578c131e",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_MOO.png",
-    "name" : "Moola",
-    "symbol" : "MOO"
+  "0x17700282592d6917f6a73d0bf8accf4d578c131e": {
+    "address": "0x17700282592d6917f6a73d0bf8accf4d578c131e",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_MOO.png",
+    "name": "Moola",
+    "symbol": "MOO"
   },
-  "0x1a8dbe5958c597a744ba51763abebd3355996c3e" : {
-    "address" : "0x1a8dbe5958c597a744ba51763abebd3355996c3e",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_rCELO.png",
-    "name" : "RewardsCELO",
-    "symbol" : "rCELO"
+  "0x1a8dbe5958c597a744ba51763abebd3355996c3e": {
+    "address": "0x1a8dbe5958c597a744ba51763abebd3355996c3e",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_rCELO.png",
+    "name": "RewardsCELO",
+    "symbol": "rCELO"
   },
-  "0x20677d4f3d0f08e735ab512393524a3cfceb250c" : {
-    "address" : "0x20677d4f3d0f08e735ab512393524a3cfceb250c",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_ARI.png",
-    "name" : "Ari Swap",
-    "symbol" : "ARI"
+  "0x20677d4f3d0f08e735ab512393524a3cfceb250c": {
+    "address": "0x20677d4f3d0f08e735ab512393524a3cfceb250c",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_ARI.png",
+    "name": "Ari Swap",
+    "symbol": "ARI"
   },
-  "0x218c3c3d49d0e7b37aff0d8bb079de36ae61a4c0" : {
-    "address" : "0x218c3c3d49d0e7b37aff0d8bb079de36ae61a4c0",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_FTM.png",
-    "name" : "Fantom",
-    "symbol" : "FTM"
+  "0x218c3c3d49d0e7b37aff0d8bb079de36ae61a4c0": {
+    "address": "0x218c3c3d49d0e7b37aff0d8bb079de36ae61a4c0",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_FTM.png",
+    "name": "Fantom",
+    "symbol": "FTM"
   },
-  "0x22401536505dd5d85f7d57f8b37172feda8f499d" : {
-    "address" : "0x22401536505dd5d85f7d57f8b37172feda8f499d",
-    "decimals" : "9",
-    "name" : "CeloShiba",
-    "symbol" : "CSHIBA"
+  "0x22401536505dd5d85f7d57f8b37172feda8f499d": {
+    "address": "0x22401536505dd5d85f7d57f8b37172feda8f499d",
+    "decimals": "9",
+    "name": "CeloShiba",
+    "symbol": "CSHIBA"
   },
-  "0x22c4c47e7d5810273a44e00339769c3b868478fc" : {
-    "address" : "0x22c4c47e7d5810273a44e00339769c3b868478fc",
-    "decimals" : 18,
-    "name" : "Impact",
-    "symbol" : "PACT"
+  "0x22c4c47e7d5810273a44e00339769c3b868478fc": {
+    "address": "0x22c4c47e7d5810273a44e00339769c3b868478fc",
+    "decimals": 18,
+    "name": "Impact",
+    "symbol": "PACT"
   },
-  "0x2879bfd5e7c4ef331384e908aaa3bd3014b703fa" : {
-    "address" : "0x2879bfd5e7c4ef331384e908aaa3bd3014b703fa",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_sCELO.png",
-    "name" : "Savings CELO",
-    "symbol" : "sCELO"
+  "0x2879bfd5e7c4ef331384e908aaa3bd3014b703fa": {
+    "address": "0x2879bfd5e7c4ef331384e908aaa3bd3014b703fa",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_sCELO.png",
+    "name": "Savings CELO",
+    "symbol": "sCELO"
   },
-  "0x2a3684e9dc20b857375ea04235f2f7edbe818fa7" : {
-    "address" : "0x2a3684e9dc20b857375ea04235f2f7edbe818fa7",
-    "decimals" : "6",
-    "name" : "USD Coin",
-    "symbol" : "USDC"
+  "0x2a3684e9dc20b857375ea04235f2f7edbe818fa7": {
+    "address": "0x2a3684e9dc20b857375ea04235f2f7edbe818fa7",
+    "decimals": "6",
+    "name": "USD Coin",
+    "symbol": "USDC"
   },
-  "0x2def4285787d58a2f811af24755a8150622f4361" : {
-    "address" : "0x2def4285787d58a2f811af24755a8150622f4361",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cETH.svg",
-    "name" : "Wrapped Ethereum",
-    "symbol" : "cETH"
+  "0x2def4285787d58a2f811af24755a8150622f4361": {
+    "address": "0x2def4285787d58a2f811af24755a8150622f4361",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cETH.svg",
+    "name": "Wrapped Ethereum",
+    "symbol": "cETH"
   },
-  "0x2e3487f967df2ebc2f236e16f8fcaeac7091324d" : {
-    "address" : "0x2e3487f967df2ebc2f236e16f8fcaeac7091324d",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_WMATIC.png",
-    "name" : "Wrapped Matic",
-    "symbol" : "WMATIC"
+  "0x2e3487f967df2ebc2f236e16f8fcaeac7091324d": {
+    "address": "0x2e3487f967df2ebc2f236e16f8fcaeac7091324d",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_WMATIC.png",
+    "name": "Wrapped Matic",
+    "symbol": "WMATIC"
   },
-  "0x301a61d01a63c8d670c2b8a43f37d12ef181f997" : {
-    "address" : "0x301a61d01a63c8d670c2b8a43f37d12ef181f997",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_pCELO.png",
-    "name" : "Poof CELO",
-    "symbol" : "pCELO"
+  "0x301a61d01a63c8d670c2b8a43f37d12ef181f997": {
+    "address": "0x301a61d01a63c8d670c2b8a43f37d12ef181f997",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_pCELO.png",
+    "name": "Poof CELO",
+    "symbol": "pCELO"
   },
-  "0x32a9fe697a32135bfd313a6ac28792dae4d9979d" : {
-    "address" : "0x32a9fe697a32135bfd313a6ac28792dae4d9979d",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cMCO2.png",
-    "name" : "cMCO2",
-    "symbol" : "cMCO2"
+  "0x32a9fe697a32135bfd313a6ac28792dae4d9979d": {
+    "address": "0x32a9fe697a32135bfd313a6ac28792dae4d9979d",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cMCO2.png",
+    "name": "cMCO2",
+    "symbol": "cMCO2"
   },
-  "0x3af556b48469d2398ab7be1563a0cfd80ea4ac84" : {
-    "address" : "0x3af556b48469d2398ab7be1563a0cfd80ea4ac84",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_WMATIC.png",
-    "name" : "Wrapped Matic",
-    "symbol" : "WMATIC"
+  "0x3af556b48469d2398ab7be1563a0cfd80ea4ac84": {
+    "address": "0x3af556b48469d2398ab7be1563a0cfd80ea4ac84",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_WMATIC.png",
+    "name": "Wrapped Matic",
+    "symbol": "WMATIC"
   },
-  "0x452ef5a4bd00796e62e5e5758548e0da6e8ccdf3" : {
-    "address" : "0x452ef5a4bd00796e62e5e5758548e0da6e8ccdf3",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cStar.png",
-    "name" : "CeloStarter",
-    "symbol" : "cStar"
+  "0x452ef5a4bd00796e62e5e5758548e0da6e8ccdf3": {
+    "address": "0x452ef5a4bd00796e62e5e5758548e0da6e8ccdf3",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cStar.png",
+    "name": "CeloStarter",
+    "symbol": "cStar"
   },
-  "0x46c9757c5497c5b1f2eb73ae79b6b67d119b0b58" : {
-    "address" : "0x46c9757c5497c5b1f2eb73ae79b6b67d119b0b58",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_PACT.png",
-    "name" : "impactMarket",
-    "symbol" : "PACT"
+  "0x46c9757c5497c5b1f2eb73ae79b6b67d119b0b58": {
+    "address": "0x46c9757c5497c5b1f2eb73ae79b6b67d119b0b58",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_PACT.png",
+    "name": "impactMarket",
+    "symbol": "PACT"
   },
-  "0x471ece3750da237f93b8e339c536989b8978a438" : {
-    "address" : "0x471ece3750da237f93b8e339c536989b8978a438",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_CELO.png",
-    "isCoreToken" : true,
-    "name" : "Celo native asset",
-    "symbol" : "CELO"
+  "0x471ece3750da237f93b8e339c536989b8978a438": {
+    "address": "0x471ece3750da237f93b8e339c536989b8978a438",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_CELO.png",
+    "isCoreToken": true,
+    "name": "Celo native asset",
+    "symbol": "CELO"
   },
-  "0x47264ae1fc0c8e6418ebe78630718e11a07346a8" : {
-    "address" : "0x47264ae1fc0c8e6418ebe78630718e11a07346a8",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_SBR.png",
-    "name" : "SBR",
-    "symbol" : "SBR"
+  "0x47264ae1fc0c8e6418ebe78630718e11a07346a8": {
+    "address": "0x47264ae1fc0c8e6418ebe78630718e11a07346a8",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_SBR.png",
+    "name": "SBR",
+    "symbol": "SBR"
   },
-  "0x48bdc1b37edc9a6b0a0b0b2fbae38e4310a51923" : {
-    "address" : "0x48bdc1b37edc9a6b0a0b0b2fbae38e4310a51923",
-    "decimals" : 18,
-    "name" : "Immortal",
-    "symbol" : "IMMO"
+  "0x48bdc1b37edc9a6b0a0b0b2fbae38e4310a51923": {
+    "address": "0x48bdc1b37edc9a6b0a0b0b2fbae38e4310a51923",
+    "decimals": 18,
+    "name": "Immortal",
+    "symbol": "IMMO"
   },
-  "0x503681c68f03bbbce48005dcd7b83ae8d4fd745c" : {
-    "address" : "0x503681c68f03bbbce48005dcd7b83ae8d4fd745c",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_AAVE.png",
-    "name" : "Aave Token",
-    "symbol" : "AAVE"
+  "0x503681c68f03bbbce48005dcd7b83ae8d4fd745c": {
+    "address": "0x503681c68f03bbbce48005dcd7b83ae8d4fd745c",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_AAVE.png",
+    "name": "Aave Token",
+    "symbol": "AAVE"
   },
-  "0x64defa3544c695db8c535d289d843a189aa26b98" : {
-    "address" : "0x64defa3544c695db8c535d289d843a189aa26b98",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mcUSDxOLD.png",
-    "name" : "Moola cUSD AToken",
-    "symbol" : "mCUSD"
+  "0x64defa3544c695db8c535d289d843a189aa26b98": {
+    "address": "0x64defa3544c695db8c535d289d843a189aa26b98",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mcUSDxOLD.png",
+    "name": "Moola cUSD AToken",
+    "symbol": "mCUSD"
   },
-  "0x6e512bfc33be36f2666754e996ff103ad1680cc9" : {
-    "address" : "0x6e512bfc33be36f2666754e996ff103ad1680cc9",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_ABR.png",
-    "name" : "Allbridge",
-    "symbol" : "ABR"
+  "0x6e512bfc33be36f2666754e996ff103ad1680cc9": {
+    "address": "0x6e512bfc33be36f2666754e996ff103ad1680cc9",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_ABR.png",
+    "name": "Allbridge",
+    "symbol": "ABR"
   },
-  "0x7037f7296b2fc7908de7b57a89efaa8319f0c500" : {
-    "address" : "0x7037f7296b2fc7908de7b57a89efaa8319f0c500",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mCELOxOLD.png",
-    "name" : "Moola CELO AToken",
-    "symbol" : "mCELO",
+  "0x7037f7296b2fc7908de7b57a89efaa8319f0c500": {
+    "address": "0x7037f7296b2fc7908de7b57a89efaa8319f0c500",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mCELOxOLD.png",
+    "name": "Moola CELO AToken",
+    "symbol": "mCELO",
     "pegTo": "0x471ece3750da237f93b8e339c536989b8978a438"
   },
-  "0x73a210637f6f6b7005512677ba6b3c96bb4aa44b" : {
-    "address" : "0x73a210637f6f6b7005512677ba6b3c96bb4aa44b",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_MOBI.png",
-    "name" : "Mobius DAO Token",
-    "symbol" : "MOBI"
+  "0x73a210637f6f6b7005512677ba6b3c96bb4aa44b": {
+    "address": "0x73a210637f6f6b7005512677ba6b3c96bb4aa44b",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_MOBI.png",
+    "name": "Mobius DAO Token",
+    "symbol": "MOBI"
   },
-  "0x74c0c58b99b68cf16a717279ac2d056a34ba2bfe" : {
-    "address" : "0x74c0c58b99b68cf16a717279ac2d056a34ba2bfe",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_SOURCE.png",
-    "name" : "Source",
-    "symbol" : "SOURCE"
+  "0x74c0c58b99b68cf16a717279ac2d056a34ba2bfe": {
+    "address": "0x74c0c58b99b68cf16a717279ac2d056a34ba2bfe",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_SOURCE.png",
+    "name": "Source",
+    "symbol": "SOURCE"
   },
-  "0x765de816845861e75a25fca122bb6898b8b1282a" : {
-    "address" : "0x765de816845861e75a25fca122bb6898b8b1282a",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cUSD.png",
-    "isCoreToken" : true,
-    "name" : "Celo Dollar",
-    "symbol" : "cUSD"
+  "0x765de816845861e75a25fca122bb6898b8b1282a": {
+    "address": "0x765de816845861e75a25fca122bb6898b8b1282a",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cUSD.png",
+    "isCoreToken": true,
+    "name": "Celo Dollar",
+    "symbol": "cUSD"
   },
-  "0x7c2bf103daac9c082a0e53ad40bb9f3f7f799af7" : {
-    "address" : "0x7c2bf103daac9c082a0e53ad40bb9f3f7f799af7",
-    "decimals" : 10,
-    "imageUrl" : "https://diquecito.com.ar/wp-content/uploads/2018/08/test.jpeg",
-    "name" : "Test Token",
-    "symbol" : "TT"
+  "0x7c2bf103daac9c082a0e53ad40bb9f3f7f799af7": {
+    "address": "0x7c2bf103daac9c082a0e53ad40bb9f3f7f799af7",
+    "decimals": 10,
+    "imageUrl": "https://diquecito.com.ar/wp-content/uploads/2018/08/test.jpeg",
+    "name": "Test Token",
+    "symbol": "TT"
   },
-  "0x7d00cd74ff385c955ea3d79e47bf06bd7386387d" : {
-    "address" : "0x7d00cd74ff385c955ea3d79e47bf06bd7386387d",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mCELO.png",
-    "name" : "Moola interest bearing CELO",
-    "symbol" : "mCELO"
+  "0x7d00cd74ff385c955ea3d79e47bf06bd7386387d": {
+    "address": "0x7d00cd74ff385c955ea3d79e47bf06bd7386387d",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mCELO.png",
+    "name": "Moola interest bearing CELO",
+    "symbol": "mCELO"
   },
   "0x8427bd503dd3169ccc9aff7326c15258bc305478": {
     "address": "0x8427bd503dd3169ccc9aff7326c15258bc305478",
@@ -243,135 +243,135 @@
     "name": "Symmetric",
     "symbol": "SYMM"
   },
-  "0x8e3670fd7b0935d3fe832711debfe13bb689b690" : {
-    "address" : "0x8e3670fd7b0935d3fe832711debfe13bb689b690",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_AVAX.png",
-    "name" : "AVAX",
-    "symbol" : "AVAX"
+  "0x8e3670fd7b0935d3fe832711debfe13bb689b690": {
+    "address": "0x8e3670fd7b0935d3fe832711debfe13bb689b690",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_AVAX.png",
+    "name": "AVAX",
+    "symbol": "AVAX"
   },
-  "0x918146359264c492bd6934071c6bd31c854edbc3" : {
-    "address" : "0x918146359264c492bd6934071c6bd31c854edbc3",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mcUSD.png",
-    "name" : "Moola interest bearing CUSD",
-    "symbol" : "mCUSD",
-    "pegTo" : "0x765de816845861e75a25fca122bb6898b8b1282a"
+  "0x918146359264c492bd6934071c6bd31c854edbc3": {
+    "address": "0x918146359264c492bd6934071c6bd31c854edbc3",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mcUSD.png",
+    "name": "Moola interest bearing CUSD",
+    "symbol": "mCUSD",
+    "pegTo": "0x765de816845861e75a25fca122bb6898b8b1282a"
   },
-  "0x94140c2ea9d208d8476ca4e3045254169791c59e" : {
-    "address" : "0x94140c2ea9d208d8476ca4e3045254169791c59e",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_PREMIO.png",
-    "name" : "PREMIO",
-    "symbol" : "PREMIO"
+  "0x94140c2ea9d208d8476ca4e3045254169791c59e": {
+    "address": "0x94140c2ea9d208d8476ca4e3045254169791c59e",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_PREMIO.png",
+    "name": "PREMIO",
+    "symbol": "PREMIO"
   },
-  "0xa649325aa7c5093d12d6f98eb4378deae68ce23f" : {
-    "address" : "0xa649325aa7c5093d12d6f98eb4378deae68ce23f",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_BNB.png",
-    "name" : "Binance",
-    "symbol" : "BNB"
+  "0xa649325aa7c5093d12d6f98eb4378deae68ce23f": {
+    "address": "0xa649325aa7c5093d12d6f98eb4378deae68ce23f",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_BNB.png",
+    "name": "Binance",
+    "symbol": "BNB"
   },
-  "0xa753eee62ab06c3ae481776d7b006c6872a9ec2e" : {
-    "address" : "0xa753eee62ab06c3ae481776d7b006c6872a9ec2e",
-    "decimals" : 18,
-    "name" : "CeloFloki",
-    "symbol" : "CFLOKI"
+  "0xa753eee62ab06c3ae481776d7b006c6872a9ec2e": {
+    "address": "0xa753eee62ab06c3ae481776d7b006c6872a9ec2e",
+    "decimals": 18,
+    "name": "CeloFloki",
+    "symbol": "CFLOKI"
   },
-  "0xa81d9a2d29373777e4082d588958678a6df5645c" : {
-    "address" : "0xa81d9a2d29373777e4082d588958678a6df5645c",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_KNX.png",
-    "name" : "KNX",
-    "symbol" : "KNX"
+  "0xa81d9a2d29373777e4082d588958678a6df5645c": {
+    "address": "0xa81d9a2d29373777e4082d588958678a6df5645c",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_KNX.png",
+    "name": "KNX",
+    "symbol": "KNX"
   },
-  "0xa8d0e6799ff3fd19c6459bf02689ae09c4d78ba7" : {
-    "address" : "0xa8d0e6799ff3fd19c6459bf02689ae09c4d78ba7",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mcEURxOLD.png",
-    "name" : "Moola cEUR MToken",
-    "symbol" : "mCEUR"
+  "0xa8d0e6799ff3fd19c6459bf02689ae09c4d78ba7": {
+    "address": "0xa8d0e6799ff3fd19c6459bf02689ae09c4d78ba7",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mcEURxOLD.png",
+    "name": "Moola cEUR MToken",
+    "symbol": "mCEUR"
   },
-  "0xbaab46e28388d2779e6e31fd00cf0e5ad95e327b" : {
-    "address" : "0xbaab46e28388d2779e6e31fd00cf0e5ad95e327b",
-    "decimals" : 8,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_WBTC.png",
-    "name" : "Wrapped BTC",
-    "symbol" : "WBTC"
+  "0xbaab46e28388d2779e6e31fd00cf0e5ad95e327b": {
+    "address": "0xbaab46e28388d2779e6e31fd00cf0e5ad95e327b",
+    "decimals": 8,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_WBTC.png",
+    "name": "Wrapped BTC",
+    "symbol": "WBTC"
   },
-  "0xbe50a3013a1c94768a1abb78c3cb79ab28fc1ace" : {
-    "address" : "0xbe50a3013a1c94768a1abb78c3cb79ab28fc1ace",
-    "decimals" : 8,
-    "name" : "Wrapped BTC",
-    "symbol" : "WBTC"
+  "0xbe50a3013a1c94768a1abb78c3cb79ab28fc1ace": {
+    "address": "0xbe50a3013a1c94768a1abb78c3cb79ab28fc1ace",
+    "decimals": 8,
+    "name": "Wrapped BTC",
+    "symbol": "WBTC"
   },
-  "0xd15ec721c2a896512ad29c671997dd68f9593226" : {
-    "address" : "0xd15ec721c2a896512ad29c671997dd68f9593226",
-    "decimals" : 18,
-    "name" : "SushiToken",
-    "symbol" : "SUSHI"
+  "0xd15ec721c2a896512ad29c671997dd68f9593226": {
+    "address": "0xd15ec721c2a896512ad29c671997dd68f9593226",
+    "decimals": 18,
+    "name": "SushiToken",
+    "symbol": "SUSHI"
   },
-  "0xd1e05db88db611f17a25478f3e6c3209460f17af" : {
-    "address" : "0xd1e05db88db611f17a25478f3e6c3209460f17af",
-    "decimals" : 18,
-    "name" : "CeloFloki",
-    "symbol" : "CFLOKI"
+  "0xd1e05db88db611f17a25478f3e6c3209460f17af": {
+    "address": "0xd1e05db88db611f17a25478f3e6c3209460f17af",
+    "decimals": 18,
+    "name": "CeloFloki",
+    "symbol": "CFLOKI"
   },
-  "0xd629eb00deced2a080b7ec630ef6ac117e614f1b" : {
-    "address" : "0xd629eb00deced2a080b7ec630ef6ac117e614f1b",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cBTC.png",
-    "name" : "Wrapped Bitcoin",
-    "symbol" : "BTC"
+  "0xd629eb00deced2a080b7ec630ef6ac117e614f1b": {
+    "address": "0xd629eb00deced2a080b7ec630ef6ac117e614f1b",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cBTC.png",
+    "name": "Wrapped Bitcoin",
+    "symbol": "BTC"
   },
-  "0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73" : {
-    "address" : "0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cEUR.png",
-    "isCoreToken" : true,
-    "name" : "Celo Euro",
-    "symbol" : "cEUR"
+  "0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73": {
+    "address": "0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cEUR.png",
+    "isCoreToken": true,
+    "name": "Celo Euro",
+    "symbol": "cEUR"
   },
-  "0xd90bbdf5904cb7d275c41f897495109b9a5ada58" : {
-    "address" : "0xd90bbdf5904cb7d275c41f897495109b9a5ada58",
-    "decimals" : "9",
-    "name" : "CeloDoge",
-    "symbol" : "CDOGE"
+  "0xd90bbdf5904cb7d275c41f897495109b9a5ada58": {
+    "address": "0xd90bbdf5904cb7d275c41f897495109b9a5ada58",
+    "decimals": "9",
+    "name": "CeloDoge",
+    "symbol": "CDOGE"
   },
-  "0xe273ad7ee11dcfaa87383ad5977ee1504ac07568" : {
-    "address" : "0xe273ad7ee11dcfaa87383ad5977ee1504ac07568",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mcEUR.png",
-    "name" : "Moola interest bearing CEUR",
-    "symbol" : "mCEUR",
-    "pegTo" : "0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73"
+  "0xe273ad7ee11dcfaa87383ad5977ee1504ac07568": {
+    "address": "0xe273ad7ee11dcfaa87383ad5977ee1504ac07568",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mcEUR.png",
+    "name": "Moola interest bearing CEUR",
+    "symbol": "mCEUR",
+    "pegTo": "0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73"
   },
-  "0xe685d21b7b0fc7a248a6a8e03b8db22d013aa2ee" : {
-    "address" : "0xe685d21b7b0fc7a248a6a8e03b8db22d013aa2ee",
-    "decimals" : "9",
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_IMMO.png",
-    "name" : "Immortal",
-    "symbol" : "IMMO"
+  "0xe685d21b7b0fc7a248a6a8e03b8db22d013aa2ee": {
+    "address": "0xe685d21b7b0fc7a248a6a8e03b8db22d013aa2ee",
+    "decimals": "9",
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_IMMO.png",
+    "name": "Immortal",
+    "symbol": "IMMO"
   },
-  "0xe74abf23e1fdf7acbec2f3a30a772ef77f1601e1" : {
-    "address" : "0xe74abf23e1fdf7acbec2f3a30a772ef77f1601e1",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_pCELO.png",
-    "name" : "Poof CELO",
-    "symbol" : "pCELO"
+  "0xe74abf23e1fdf7acbec2f3a30a772ef77f1601e1": {
+    "address": "0xe74abf23e1fdf7acbec2f3a30a772ef77f1601e1",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_pCELO.png",
+    "name": "Poof CELO",
+    "symbol": "pCELO"
   },
-  "0xe8537a3d056da446677b9e9d6c5db704eaab4787" : {
-    "address" : "0xe8537a3d056da446677b9e9d6c5db704eaab4787",
-    "decimals" : 18,
-    "imageUrl" : "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cREAL.png",
-    "isCoreToken" : true,
-    "name" : "Celo Brazilian Real",
-    "symbol" : "cREAL"
+  "0xe8537a3d056da446677b9e9d6c5db704eaab4787": {
+    "address": "0xe8537a3d056da446677b9e9d6c5db704eaab4787",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cREAL.png",
+    "isCoreToken": true,
+    "name": "Celo Brazilian Real",
+    "symbol": "cREAL"
   },
-  "0xe919f65739c26a42616b7b8eedc6b5524d1e3ac4" : {
-    "address" : "0xe919f65739c26a42616b7b8eedc6b5524d1e3ac4",
-    "decimals" : 18,
-    "name" : "Wrapped Ether",
-    "symbol" : "WETH"
+  "0xe919f65739c26a42616b7b8eedc6b5524d1e3ac4": {
+    "address": "0xe919f65739c26a42616b7b8eedc6b5524d1e3ac4",
+    "decimals": 18,
+    "name": "Wrapped Ether",
+    "symbol": "WETH"
   }
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,7 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": [
-    "src/**/*.ts"
-  ],
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,9 +17,6 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true
   },
-  "include": [
-    "src/**/*.ts",
-    "types/*.ts"
-  ],
+  "include": ["src/**/*.ts", "types/*.ts"],
   "exclude": ["node_modules/**/*"]
 }


### PR DESCRIPTION
Makes sure all files supported by prettier are formatted and checked.
In preparation for #14.

I updated the scripts in `package.json` and let prettier format the files. 
i.e. I did not modify any data.