### PR TITLE
fix(validation): allow upper and mixed case addresses

### DIFF
--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -1,16 +1,25 @@
 import allMetadata from './data/'
-import AddressSchema from "./schemas/address-schema";
+import AddressSchema from './schemas/address-schema'
 
 describe('Schemas work as expected', () => {
   describe('AddressSchema', () => {
     it('allows uppercase', () => {
-      expect(AddressSchema.validate('0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA').error).toBeUndefined()
+      expect(
+        AddressSchema.validate('0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')
+          .error,
+      ).toBeUndefined()
     })
     it('allows mixed case', () => {
-      expect(AddressSchema.validate('0xaaaaaaaaaaaaaaaaaaaaAAAAAAAAAAAAAAAAAAAA').error).toBeUndefined()
+      expect(
+        AddressSchema.validate('0xaaaaaaaaaaaaaaaaaaaaAAAAAAAAAAAAAAAAAAAA')
+          .error,
+      ).toBeUndefined()
     })
     it('allows lowercase', () => {
-      expect(AddressSchema.validate('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa').error).toBeUndefined()
+      expect(
+        AddressSchema.validate('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+          .error,
+      ).toBeUndefined()
     })
   })
 })

--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -1,4 +1,19 @@
 import allMetadata from './data/'
+import AddressSchema from "./schemas/address-schema";
+
+describe('Schemas work as expected', () => {
+  describe('AddressSchema', () => {
+    it('allows uppercase', () => {
+      expect(AddressSchema.validate('0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA').error).toBeUndefined()
+    })
+    it('allows mixed case', () => {
+      expect(AddressSchema.validate('0xaaaaaaaaaaaaaaaaaaaaAAAAAAAAAAAAAAAAAAAA').error).toBeUndefined()
+    })
+    it('allows lowercase', () => {
+      expect(AddressSchema.validate('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa').error).toBeUndefined()
+    })
+  })
+})
 
 describe('Schema validation', () => {
   Object.entries(allMetadata).forEach(([project, projectMetadata]) => {

--- a/src/schemas/address-schema.ts
+++ b/src/schemas/address-schema.ts
@@ -1,5 +1,5 @@
 import Joi from 'joi'
 
-const AddressSchema = Joi.string().regex(/^0x[a-f0-9]{40}$/)
+const AddressSchema = Joi.string().regex(/^0x[a-fA-F0-9]{40}$/)
 
 export default AddressSchema


### PR DESCRIPTION
Our address validation regex caused tests to fail if mixed or upper case addresses were used. I don't know of any reason we need this. cRecy came across this when trying to add their token.