### PR TITLE
Fix issue where `yarn update` fails for clean Firebase RTDB Instance

### DIFF
--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -112,4 +112,17 @@ describe('Delete Missing Keys UpdateRequest', () => {
 
     expect(updateObject).toMatchObject({})
   })
+
+  it('creates all keys if the RTDB instance is clean', () => {
+    const expected = {
+      key1: 1,
+      key2: 'value',
+    }
+
+    const current = null
+
+    const updateObject = deleteMissingKeysUpdateRequest(expected, current)
+
+    expect(updateObject).toMatchObject({})
+  })
 })

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -31,6 +31,7 @@ function isNonEmptyObject(json: any): boolean {
 }
 
 export function deleteMissingKeysUpdateRequest(expected: any, current: any) {
+  if (current == null) return
   const expectedKeys = new Set(Object.keys(expected))
   const currentKeys = Object.keys(current)
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -31,7 +31,7 @@ function isNonEmptyObject(json: any): boolean {
 }
 
 export function deleteMissingKeysUpdateRequest(expected: any, current: any) {
-  if (current == null) return
+  if (!isNonEmptyObject(current)) return {}
   const expectedKeys = new Set(Object.keys(expected))
   const currentKeys = Object.keys(current)
 


### PR DESCRIPTION
**Description**

If this project is run against a fresh Firebase RTDB project, the `deleteMissingKeysAndUpdate` function will fail when trying to enumerate the `current` tokensInfo in the following line

```ts
const currentKeys = Object.keys(current)
```

**Impact**

Users that intent to use this repo to create their own Firebase RTDB will not be able to write the initial tokensInfo set to the RTDB instance.