### PR TITLE
ci: fix gcloud auth

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -41,7 +41,7 @@ jobs:
       - run: yarn test:ci
   update-alfajores:
     name: Update Alfajores RTDB
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     needs:
       - lint
       - test

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -48,11 +48,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: google-github-actions/setup-gcloud@v1
+      - uses: google-github-actions/auth@v1
         with:
           project_id: celo-mobile-alfajores
-          service_account_key: ${{ secrets.ALFAJORES_SERVICE_ACCOUNT_KEY }}
-          export_default_credentials: true
+          credentials_json: ${{ secrets.ALFAJORES_SERVICE_ACCOUNT_KEY }}
+      - uses: google-github-actions/setup-gcloud@v1
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
@@ -67,11 +67,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: google-github-actions/setup-gcloud@v1
+      - uses: google-github-actions/auth@v1
         with:
-          project_id: celo-mobile-mainnet
-          service_account_key: ${{ secrets.MAINNET_SERVICE_ACCOUNT_KEY }}
-          export_default_credentials: true
+          project_id: celo-mobile-alfajores
+          credentials_json: ${{ secrets.MAINNET_SERVICE_ACCOUNT_KEY }}
+      - uses: google-github-actions/setup-gcloud@v1
       - uses: actions/setup-node@v3
         with:
           node-version: '16'

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -41,7 +41,7 @@ jobs:
       - run: yarn test:ci
   update-alfajores:
     name: Update Alfajores RTDB
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
     needs:
       - lint
       - test


### PR DESCRIPTION
We now need the `google-github-actions/auth` action first.

See [failed action](https://github.com/valora-inc/address-metadata/actions/runs/4007265222/jobs/6879892191):
<img width="962" alt="Screenshot 2023-01-25 at 16 20 07" src="https://user-images.githubusercontent.com/57791/214602391-edfc12e7-6444-443e-941d-cc6d0342b083.png">

Tested successfully in https://github.com/valora-inc/address-metadata/actions/runs/4007356862/jobs/6880099011