### PR TITLE
fix(swaps): Disable swapping btc until decimals bug is fixed.

### DIFF
--- a/src/data/mainnet/tokens-info.json
+++ b/src/data/mainnet/tokens-info.json
@@ -322,7 +322,7 @@
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/WBTC.png",
     "name": "Wrapped BTC",
     "symbol": "WBTC",
-    "isSwappable": true
+    "isSwappable": false
   },
   {
     "address": "0xbe50a3013a1c94768a1abb78c3cb79ab28fc1ace",


### PR DESCRIPTION
### Description

[We are not handling correctly](https://linear.app/valora/issue/RET-712/[wallet]-swapping-tokens-with-different-decimals-is-not-working) the `decimals` in the swap flow.
We should disable btc in the swap until the bug is fixed.