### PR TITLE
Disabling swaps with stcelo

### DIFF
--- a/src/data/mainnet/tokens-info.json
+++ b/src/data/mainnet/tokens-info.json
@@ -12,7 +12,7 @@
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/stCELO.png",
     "name": "Staked Celo",
     "symbol": "stCELO",
-    "isSwappable": true
+    "isSwappable": false
   },
   {
     "address": "0x00be915b9dcf56a3cbe739d9b9c202ca692409ec",


### PR DESCRIPTION
Disabling stCelo because it has low liquidity, offering really bad exchange rates.