### PR TITLE
chore(bq): upload to US region

### DIFF
--- a/scripts/update-bq.ts
+++ b/scripts/update-bq.ts
@@ -19,7 +19,7 @@ const rows = jsonData.map((entry) => {
 })
 
 async function overwriteTable() {
-  const dataset = bigquery.dataset(datasetId, { projectId })
+  const dataset = bigquery.dataset(datasetId, { projectId, location: 'US' })
   const table = dataset.table(tableId)
 
   const writeStream = table.createWriteStream({


### PR DESCRIPTION
The script was defaulting to `us-central1` unlike all of our other data which is multi-region 'US'. Querying a single region table along with our other multiregion tables in a single query was causing some issues.

<img width="858" alt="Screen Shot 2023-09-06 at 12 06 28 PM" src="https://github.com/valora-inc/address-metadata/assets/8432644/e2b20d19-c568-4bd0-aed0-3a7448aa0825">
