### PR TITLE
refactor(networkId): switch from network to networkId on TokenInfo type

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import { _getTokensInfoHttpFunction } from './index'
 import { loadCloudFunctionConfig } from './config'
-import { Network, NetworkId } from './types'
+import { NetworkId } from './types'
 import { getTokensInfo } from './tokens-info'
 import mocked = jest.mocked
 
@@ -17,7 +17,7 @@ describe('index', () => {
     })
     const mockTokensInfo = {
       'ethereum-mainnet:native': {
-        network: Network.ethereum,
+        networkId: NetworkId['ethereum-mainnet'],
         name: 'Ether',
         symbol: 'ETH',
         decimals: 18,
@@ -34,7 +34,7 @@ describe('index', () => {
         name: 'Celo native asset',
         symbol: 'CELO',
         isNative: true,
-        network: Network.celo,
+        networkId: NetworkId['celo-mainnet'],
       },
     }
     mocked(getTokensInfo).mockReturnValue(mockTokensInfo)

--- a/src/schemas/tokens-info.ts
+++ b/src/schemas/tokens-info.ts
@@ -4,7 +4,7 @@ import { URL } from 'url'
 import path from 'path'
 import AddressSchema from './address-schema'
 import semver from 'semver'
-import { Network } from '../types'
+import { NetworkId } from '../types'
 
 export const checkMatchingAsset = (value: string) => {
   const url = new URL(value)
@@ -52,7 +52,7 @@ const BaseTokenInfoSchema = Joi.object({
     .pattern(/^\d+\.\d+\.\d+$/)
     .custom(checkMinVersion, 'has a valid version'),
   isNative: Joi.boolean(),
-  network: Joi.valid(...Object.values(Network)),
+  networkId: Joi.valid(...Object.values(NetworkId)),
 })
 
 export const TokenInfoSchema = Joi.alternatives().try(

--- a/src/tokens-info.ts
+++ b/src/tokens-info.ts
@@ -1,22 +1,16 @@
-import { Network, NetworkId, TokenInfo } from './types'
+import { NetworkId, TokenInfo } from './types'
 import CeloMainnetTokensInfo from './data/mainnet/celo-tokens-info.json'
 import CeloAlfajoresTokensInfo from './data/testnet/celo-alfajores-tokens-info.json'
 import EthereumMainnetTokensInfo from './data/mainnet/ethereum-tokens-info.json'
 import EthereumSepoliaTokensInfo from './data/testnet/ethereum-sepolia-tokens-info.json'
 
-const networkIdToTokensInfo: Record<NetworkId, Omit<TokenInfo, 'network'>[]> = {
-  [NetworkId['celo-mainnet']]: CeloMainnetTokensInfo,
-  [NetworkId['celo-alfajores']]: CeloAlfajoresTokensInfo,
-  [NetworkId['ethereum-mainnet']]: EthereumMainnetTokensInfo,
-  [NetworkId['ethereum-sepolia']]: EthereumSepoliaTokensInfo,
-}
-
-const networkIdToNetwork: Record<NetworkId, Network> = {
-  [NetworkId['celo-mainnet']]: Network.celo,
-  [NetworkId['celo-alfajores']]: Network.celo,
-  [NetworkId['ethereum-mainnet']]: Network.ethereum,
-  [NetworkId['ethereum-sepolia']]: Network.ethereum,
-}
+const networkIdToTokensInfo: Record<NetworkId, Omit<TokenInfo, 'networkId'>[]> =
+  {
+    [NetworkId['celo-mainnet']]: CeloMainnetTokensInfo,
+    [NetworkId['celo-alfajores']]: CeloAlfajoresTokensInfo,
+    [NetworkId['ethereum-mainnet']]: EthereumMainnetTokensInfo,
+    [NetworkId['ethereum-sepolia']]: EthereumSepoliaTokensInfo,
+  }
 
 export function getTokenId(
   { isNative, address }: Partial<TokenInfo>,
@@ -30,9 +24,8 @@ export function getTokensInfo(networkIds: NetworkId[]): {
 } {
   const output: { [tokenId: string]: TokenInfo } = {}
   for (const networkId of networkIds) {
-    const network = networkIdToNetwork[networkId]
     for (const tokenInfo of networkIdToTokensInfo[networkId]) {
-      output[getTokenId(tokenInfo, networkId)] = { ...tokenInfo, network }
+      output[getTokenId(tokenInfo, networkId)] = { ...tokenInfo, networkId }
     }
   }
   return output

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ export interface TokenInfo {
   name: string
   symbol: string
   decimals: number
-  network: Network
+  networkId: NetworkId
   address?: string
   imageUrl?: string
   isNative?: boolean
@@ -42,12 +42,7 @@ export interface TokenInfo {
   isSupercharged?: boolean
 }
 
-export enum Network { // environment-agnostic network name
-  celo = 'celo',
-  ethereum = 'ethereum',
-}
-
-export enum NetworkId { // environment-specific
+export enum NetworkId {
   ['celo-mainnet'] = 'celo-mainnet',
   ['celo-alfajores'] = 'celo-alfajores',
   ['ethereum-mainnet'] = 'ethereum-mainnet',

--- a/src/utils/transforms.ts
+++ b/src/utils/transforms.ts
@@ -1,10 +1,10 @@
 import { TokenInfo } from '../types'
 
-type CeloRTDBTokenInfo = Omit<TokenInfo, 'network' | 'isNative'>
+type CeloRTDBTokenInfo = Omit<TokenInfo, 'networkId' | 'isNative'>
 
 // Transforms the Celo tokens info data in this repo into the format used in the RTDB collection
 export function transformCeloTokensForRTDB(
-  celoTokensInfo: Omit<TokenInfo, 'network'>[],
+  celoTokensInfo: Omit<TokenInfo, 'networkId'>[],
 ): Record<string, CeloRTDBTokenInfo> {
   return Object.fromEntries(
     celoTokensInfo.map((rawTokenInfo) => {


### PR DESCRIPTION
in the wallet, we will need some mapping from the network field to a subtitle to show in the transaction feed. if we want to show "Celo Alfajores Network" in the feed at some point as opposed to just "Celo Network" (particularly if we enable some "dev mode" in the future), we'll need information about the environment (testnet vs mainnet) as well as the network (eth vs celo vs ...). This PR updates TokenInfo to include that information by using an environment-specific networkId, rather than just "network". 