### PR TITLE
chore: rename Celo native asset to Celo

### DIFF
--- a/src/data/mainnet/celo-tokens-info.json
+++ b/src/data/mainnet/celo-tokens-info.json
@@ -181,7 +181,7 @@
     "decimals": 18,
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/CELO.png",
     "isCoreToken": true,
-    "name": "Celo native asset",
+    "name": "Celo",
     "symbol": "CELO",
     "isSwappable": true,
     "isNative": true

--- a/src/data/testnet/celo-alfajores-tokens-info.json
+++ b/src/data/testnet/celo-alfajores-tokens-info.json
@@ -181,7 +181,7 @@
     "decimals": 18,
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/CELO.png",
     "isCoreToken": true,
-    "name": "Celo native asset",
+    "name": "Celo",
     "symbol": "CELO",
     "isNative": true
   },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -31,7 +31,7 @@ describe('index', () => {
         imageUrl:
           'https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/CELO.png',
         isCoreToken: true,
-        name: 'Celo native asset',
+        name: 'Celo',
         symbol: 'CELO',
         isNative: true,
         networkId: NetworkId['celo-mainnet'],

--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -89,7 +89,7 @@ describe('Schema validation', () => {
               imageUrl:
                 'https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/CELO.png',
               isCoreToken: true,
-              name: 'Celo native asset',
+              name: 'Celo',
               symbol: 'CELO',
               isSwappable: true,
               isNative: true,


### PR DESCRIPTION
### Description

As per the title this renames `Celo native asset` to simply `Celo`. With the incoming new address structure the existing name is redundant and not localized.