### PR TITLE
chore: Make getTokensInfoCF 2nd gen cloud function

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -106,7 +106,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn
       - run: yarn build
-      - run: yarn deploy:dev getTokensInfoCF
+      - run: yarn deploy:dev --entry-point=getTokensInfoCF get-tokens-info
   deploy-prod:
     name: Deploy prod cloud function
     if: github.ref == 'refs/heads/main'
@@ -136,4 +136,4 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn
       - run: yarn build
-      - run: yarn deploy:prod getTokensInfoCF
+      - run: yarn deploy:prod --entry-point=getTokensInfoCF get-tokens-info

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -106,7 +106,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn
       - run: yarn build
-      - run: yarn deploy:dev --entry-point=getTokensInfoCF get-tokens-info
+      - run: yarn deploy:dev getTokensInfo
   deploy-prod:
     name: Deploy prod cloud function
     if: github.ref == 'refs/heads/main'
@@ -136,4 +136,4 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn
       - run: yarn build
-      - run: yarn deploy:prod --entry-point=getTokensInfoCF get-tokens-info
+      - run: yarn deploy:prod getTokensInfo

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "supercheck": "yarn format && yarn lint:fix && yarn typecheck && yarn test",
     "diff": "ts-node scripts/diff.ts",
     "update:rtdb": "ts-node scripts/update-rtdb.ts",
-    "deploy:dev": "gcloud functions deploy --project=celo-mobile-alfajores --runtime=nodejs20 --trigger-http --allow-unauthenticated --security-level=secure-always --ingress-settings=internal-and-gclb --env-vars-file=config-dev.yaml",
-    "deploy:prod": "gcloud functions deploy --project=celo-mobile-mainnet --runtime=nodejs20 --trigger-http --allow-unauthenticated --security-level=secure-always --ingress-settings=internal-and-gclb --env-vars-file=config-prod.yaml"
+    "deploy:dev": "gcloud beta functions deploy --gen2 --region=us-central1 --concurrency=80 --cpu=1 --memory=256MB --project=celo-mobile-alfajores --runtime=nodejs20 --trigger-http --allow-unauthenticated --env-vars-file=config-dev.yaml",
+    "deploy:prod": "gcloud beta functions deploy --gen2 --region=us-central1 --concurrency=80 --cpu=1 --memory=256MB --project=celo-mobile-mainnet --runtime=nodejs20 --trigger-http --allow-unauthenticated --env-vars-file=config-prod.yaml"
   },
   "prettier": "@valora/prettier-config",
   "repository": "git@github.com:valora-inc/rtdb-data.git",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
 import { _getTokensInfoHttpFunction } from './index'
 import { loadCloudFunctionConfig } from './config'
 import { NetworkId } from './types'
-import { getTokensInfo } from './tokens-info'
+import { getTokensInfoByNetworkIds } from './tokens-info'
 import mocked = jest.mocked
 
 jest.mock('./config')
@@ -37,7 +37,7 @@ describe('index', () => {
         networkId: NetworkId['celo-mainnet'],
       },
     }
-    mocked(getTokensInfo).mockReturnValue(mockTokensInfo)
+    mocked(getTokensInfoByNetworkIds).mockReturnValue(mockTokensInfo)
     await _getTokensInfoHttpFunction(req, res)
     expect(res.status).toHaveBeenCalledWith(200)
     expect(res.send).toHaveBeenCalledWith(mockTokensInfo)

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { RTDBAddressToTokenInfoSchema } from './schemas/tokens-info'
 import { HttpFunction } from '@google-cloud/functions-framework'
 import { wrap } from './wrap'
 import { loadCloudFunctionConfig } from './config'
-import { getTokensInfo } from './tokens-info'
+import { getTokensInfoByNetworkIds } from './tokens-info'
 
 export function getCeloRTDBMetadata(environment: Environment): RTDBMetadata[] {
   const [tokensInfo, addressesExtraInfo] =
@@ -34,13 +34,11 @@ export function getCeloRTDBMetadata(environment: Environment): RTDBMetadata[] {
 
 export const _getTokensInfoHttpFunction: HttpFunction = async (_req, res) => {
   const { networkIds } = loadCloudFunctionConfig() // in the future we could use this as a default set of network id's to include in the response, and accept a list of network id's as a query param to override it
-  const tokensInfo = getTokensInfo(networkIds)
+  const tokensInfo = getTokensInfoByNetworkIds(networkIds)
   res.status(200).send({ ...tokensInfo })
 }
 
-// named this way to avoid collision with cloud function getTokensInfo from valora-rest-api.
-//  TODO deprecate getTokensInfo cloud function from valora-rest-api
-export const getTokensInfoCF: HttpFunction = wrap({
+export const getTokensInfo: HttpFunction = wrap({
   loadConfig: loadCloudFunctionConfig,
   httpFunction: _getTokensInfoHttpFunction,
 })

--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -1,5 +1,5 @@
 import { getCeloRTDBMetadata } from './index'
-import { getTokensInfo } from './tokens-info'
+import { getTokensInfoByNetworkIds } from './tokens-info'
 import { NetworkId, TokenInfo } from './types'
 import {
   RTDBAddressToTokenInfoSchema,
@@ -113,7 +113,7 @@ describe('Schema validation', () => {
 
   describe('Tokens info data', () => {
     const tokensInfo: TokenInfo[] = Object.values(
-      getTokensInfo(Object.values(NetworkId)),
+      getTokensInfoByNetworkIds(Object.values(NetworkId)),
     )
     it.each(tokensInfo)('tokenInfo %o', (tokenInfo) => {
       const validationResult = validateWithSchema(tokenInfo, TokenInfoSchema)
@@ -123,7 +123,9 @@ describe('Schema validation', () => {
       for (const networkId of Object.values(NetworkId)) {
         const addresses = []
         const pegToAddresses = []
-        for (const tokenInfo of Object.values(getTokensInfo([networkId]))) {
+        for (const tokenInfo of Object.values(
+          getTokensInfoByNetworkIds([networkId]),
+        )) {
           if (tokenInfo.address) {
             addresses.push(tokenInfo.address)
           }

--- a/src/tokens-info.ts
+++ b/src/tokens-info.ts
@@ -19,7 +19,7 @@ export function getTokenId(
   return `${networkId}:${isNative ? 'native' : address}`
 }
 
-export function getTokensInfo(networkIds: NetworkId[]): {
+export function getTokensInfoByNetworkIds(networkIds: NetworkId[]): {
   [tokenId: string]: TokenInfo
 } {
   const output: { [tokenId: string]: TokenInfo } = {}


### PR DESCRIPTION
Deployment scripts are changed to deploy `getTokensInfoCF` as a [2nd gen](https://cloud.google.com/functions/docs/concepts/version-comparison) cloud function.

#### Motivation

We noticed while implementing supercharge that cloud functions that call other cloud functions often incurs the cold start penalty. We observed a 5-6s performance impact.

While we don't know for sure what impact this will have, we know that this CF will be called for updating and retrieving token prices and it is low lift to make this optimisation already.

#### Name

New name for cloud function is `getTokensInfo`. I's a replacement for a [deprecated function](https://github.com/valora-inc/valora-rest-api/pull/645) from `valora-rest-api`.

Note: Currently 2nd gen functions naming convention [do support uppercase letters and underscores](https://stackoverflow.com/a/75974204/6766695) along with lowercase letters, numbers and hyphens, so it looks natural to reuse good old name.

#### Public availability

Function is made publicly available to facilitate future local development of `blockchain-api`.

#### URLs

##### Mainnet

https://us-central1-celo-mobile-mainnet.cloudfunctions.net/getTokensInfo

##### Testnet

https://us-central1-celo-mobile-alfajores.cloudfunctions.net/getTokensInfo

#### Explicit deployment parameters
* concurrency = `80`
* cpu = `1`
* memory = `256MB`

Note: `cpu` and `memory` are required when specifying `concurrency`.

### Test plan

- Manually deployed on the testnet project
- Manually tested `GET` request

### Related issues

- Fixes [RET-846](https://linear.app/valora/issue/RET-846/make-gettokensinfocf-gen-2)


