### PR TITLE
feat(get-tokens-info): add tokenId to tokenInfo

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -24,6 +24,7 @@ describe('index', () => {
         isNative: true,
         imageUrl:
           'https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/ETH.png',
+        tokenId: 'ethereum-mainnet:native',
       },
       'celo-mainnet:native': {
         address: '0x471ece3750da237f93b8e339c536989b8978a438',
@@ -35,6 +36,7 @@ describe('index', () => {
         symbol: 'CELO',
         isNative: true,
         networkId: NetworkId['celo-mainnet'],
+        tokenId: 'celo-mainnet:native'
       },
     }
     mocked(getTokensInfoByNetworkIds).mockReturnValue(mockTokensInfo)

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -36,7 +36,7 @@ describe('index', () => {
         symbol: 'CELO',
         isNative: true,
         networkId: NetworkId['celo-mainnet'],
-        tokenId: 'celo-mainnet:native'
+        tokenId: 'celo-mainnet:native',
       },
     }
     mocked(getTokensInfoByNetworkIds).mockReturnValue(mockTokensInfo)

--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -1,6 +1,6 @@
 import { getCeloRTDBMetadata } from './index'
 import { getTokensInfoByNetworkIds } from './tokens-info'
-import { NetworkId, TokenInfoProcessed } from './types'
+import { NetworkId, TokenInfo } from './types'
 import {
   TokenInfoSchemaProcessed,
   RTDBAddressToTokenInfoSchema,
@@ -113,7 +113,7 @@ describe('Schema validation', () => {
   })
 
   describe('Tokens info data', () => {
-    const tokensInfo: TokenInfoProcessed[] = Object.values(
+    const tokensInfo: TokenInfo[] = Object.values(
       getTokensInfoByNetworkIds(Object.values(NetworkId)),
     )
     it.each(tokensInfo)('tokenInfo %o', (tokenInfo) => {

--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -1,9 +1,10 @@
 import { getCeloRTDBMetadata } from './index'
 import { getTokensInfoByNetworkIds } from './tokens-info'
-import { NetworkId, TokenInfo } from './types'
+import { NetworkId, TokenInfoProcessed } from './types'
 import {
+  TokenInfoSchemaProcessed,
   RTDBAddressToTokenInfoSchema,
-  TokenInfoSchema,
+  TokenInfoSchemaJSON,
 } from './schemas/tokens-info'
 import Joi from 'joi'
 
@@ -24,7 +25,7 @@ describe('Schema validation', () => {
             symbol: 'CELO',
             decimals: 18,
           },
-          TokenInfoSchema,
+          TokenInfoSchemaJSON,
         )
         expect(validationResult.error).toBeDefined()
       })
@@ -37,7 +38,7 @@ describe('Schema validation', () => {
             isNative: true,
             address: '0x471ece3750da237f93b8e339c536989b8978a438',
           },
-          TokenInfoSchema,
+          TokenInfoSchemaJSON,
         )
         expect(validationResult.error).toBeDefined()
       })
@@ -48,7 +49,7 @@ describe('Schema validation', () => {
             symbol: 'XYZ',
             decimals: 18,
           },
-          TokenInfoSchema,
+          TokenInfoSchemaJSON,
         )
         expect(validationResult.error).toBeDefined()
       })
@@ -112,11 +113,11 @@ describe('Schema validation', () => {
   })
 
   describe('Tokens info data', () => {
-    const tokensInfo: TokenInfo[] = Object.values(
+    const tokensInfo: TokenInfoProcessed[] = Object.values(
       getTokensInfoByNetworkIds(Object.values(NetworkId)),
     )
     it.each(tokensInfo)('tokenInfo %o', (tokenInfo) => {
-      const validationResult = validateWithSchema(tokenInfo, TokenInfoSchema)
+      const validationResult = validateWithSchema(tokenInfo, TokenInfoSchemaProcessed)
       expect(validationResult.error).toBe(undefined)
     })
     it('pegTo fields are addresses for valid tokens', () => {

--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -117,7 +117,10 @@ describe('Schema validation', () => {
       getTokensInfoByNetworkIds(Object.values(NetworkId)),
     )
     it.each(tokensInfo)('tokenInfo %o', (tokenInfo) => {
-      const validationResult = validateWithSchema(tokenInfo, TokenInfoSchemaProcessed)
+      const validationResult = validateWithSchema(
+        tokenInfo,
+        TokenInfoSchemaProcessed,
+      )
       expect(validationResult.error).toBe(undefined)
     })
     it('pegTo fields are addresses for valid tokens', () => {

--- a/src/schemas/tokens-info.ts
+++ b/src/schemas/tokens-info.ts
@@ -56,7 +56,7 @@ const BaseTokenInfoSchema = Joi.object({
 
 const ProcessedTokenInfoSchema = BaseTokenInfoSchema.concat(
   Joi.object({
-    networkId: Joi.valid(...Object.values(NetworkId)),
+    networkId: Joi.valid(...Object.values(NetworkId)).required(),
     tokenId: Joi.string().required(),
   }),
 )

--- a/src/schemas/tokens-info.ts
+++ b/src/schemas/tokens-info.ts
@@ -4,6 +4,7 @@ import { URL } from 'url'
 import path from 'path'
 import AddressSchema from './address-schema'
 import semver from 'semver'
+import { NetworkId } from '../types'
 
 export const checkMatchingAsset = (value: string) => {
   const url = new URL(value)
@@ -55,7 +56,7 @@ const BaseTokenInfoSchema = Joi.object({
 
 const ProcessedTokenInfoSchema = BaseTokenInfoSchema.concat(
   Joi.object({
-    networkId: Joi.string().required(),
+    networkId: Joi.valid(...Object.values(NetworkId)),
     tokenId: Joi.string().required(),
   }),
 )

--- a/src/schemas/tokens-info.ts
+++ b/src/schemas/tokens-info.ts
@@ -53,35 +53,40 @@ const BaseTokenInfoSchema = Joi.object({
   isNative: Joi.boolean(),
 })
 
-const ProcessedTokenInfoSchema = BaseTokenInfoSchema.concat(Joi.object({
-  networkId: Joi.string().required(),
-  tokenId: Joi.string().required(),
-}))
-
-const getTokenInfoSchema = (base: Joi.ObjectSchema<any>) => Joi.alternatives().try(
+const ProcessedTokenInfoSchema = BaseTokenInfoSchema.concat(
   Joi.object({
-    // native tokens don't have an address except CELO
-    isNative: Joi.valid(true).required(),
-    symbol: Joi.string().invalid('CELO').required(),
-    address: Joi.forbidden(),
-  }).concat(base),
-  Joi.object({
-    // CELO is native and has an address
-    isNative: Joi.valid(true).required(),
-    symbol: Joi.valid('CELO').required(),
-    address: AddressSchema.required(),
-  }).concat(base),
-  Joi.object({
-    // all non-native tokens require address
-    isNative: Joi.boolean().invalid(true),
-    symbol: Joi.string().required(),
-    address: AddressSchema.required(),
-    bridge: Joi.string().optional(),
-  }).concat(base),
+    networkId: Joi.string().required(),
+    tokenId: Joi.string().required(),
+  }),
 )
 
+const getTokenInfoSchema = (base: Joi.ObjectSchema<any>) =>
+  Joi.alternatives().try(
+    Joi.object({
+      // native tokens don't have an address except CELO
+      isNative: Joi.valid(true).required(),
+      symbol: Joi.string().invalid('CELO').required(),
+      address: Joi.forbidden(),
+    }).concat(base),
+    Joi.object({
+      // CELO is native and has an address
+      isNative: Joi.valid(true).required(),
+      symbol: Joi.valid('CELO').required(),
+      address: AddressSchema.required(),
+    }).concat(base),
+    Joi.object({
+      // all non-native tokens require address
+      isNative: Joi.boolean().invalid(true),
+      symbol: Joi.string().required(),
+      address: AddressSchema.required(),
+      bridge: Joi.string().optional(),
+    }).concat(base),
+  )
+
 export const TokenInfoSchemaJSON = getTokenInfoSchema(BaseTokenInfoSchema)
-export const TokenInfoSchemaProcessed = getTokenInfoSchema(ProcessedTokenInfoSchema)
+export const TokenInfoSchemaProcessed = getTokenInfoSchema(
+  ProcessedTokenInfoSchema,
+)
 
 export const RTDBAddressToTokenInfoSchema = Joi.object().pattern(
   AddressSchema,

--- a/src/tokens-info.ts
+++ b/src/tokens-info.ts
@@ -24,10 +24,11 @@ export function getTokensInfoByNetworkIds(networkIds: NetworkId[]): {
   const output: { [tokenId: string]: TokenInfoProcessed } = {}
   for (const networkId of networkIds) {
     for (const tokenInfo of networkIdToTokensInfo[networkId]) {
-      output[getTokenId(tokenInfo, networkId)] = {
+      const tokenId = getTokenId(tokenInfo, networkId)
+      output[tokenId] = {
         ...tokenInfo,
         networkId,
-        tokenId: getTokenId(tokenInfo, networkId),
+        tokenId,
       }
     }
   }

--- a/src/tokens-info.ts
+++ b/src/tokens-info.ts
@@ -1,10 +1,10 @@
-import { NetworkId, TokenInfo } from './types'
+import { NetworkId, TokenInfoProcessed, TokenInfoJSON } from './types'
 import CeloMainnetTokensInfo from './data/mainnet/celo-tokens-info.json'
 import CeloAlfajoresTokensInfo from './data/testnet/celo-alfajores-tokens-info.json'
 import EthereumMainnetTokensInfo from './data/mainnet/ethereum-tokens-info.json'
 import EthereumSepoliaTokensInfo from './data/testnet/ethereum-sepolia-tokens-info.json'
 
-const networkIdToTokensInfo: Record<NetworkId, Omit<TokenInfo, 'networkId'>[]> =
+const networkIdToTokensInfo: Record<NetworkId, TokenInfoJSON[]> =
   {
     [NetworkId['celo-mainnet']]: CeloMainnetTokensInfo,
     [NetworkId['celo-alfajores']]: CeloAlfajoresTokensInfo,
@@ -13,19 +13,19 @@ const networkIdToTokensInfo: Record<NetworkId, Omit<TokenInfo, 'networkId'>[]> =
   }
 
 export function getTokenId(
-  { isNative, address }: Partial<TokenInfo>,
+  { isNative, address }: Partial<TokenInfoProcessed>,
   networkId: NetworkId,
 ): string {
   return `${networkId}:${isNative ? 'native' : address}`
 }
 
 export function getTokensInfoByNetworkIds(networkIds: NetworkId[]): {
-  [tokenId: string]: TokenInfo
+  [tokenId: string]: TokenInfoProcessed
 } {
-  const output: { [tokenId: string]: TokenInfo } = {}
+  const output: { [tokenId: string]: TokenInfoProcessed } = {}
   for (const networkId of networkIds) {
     for (const tokenInfo of networkIdToTokensInfo[networkId]) {
-      output[getTokenId(tokenInfo, networkId)] = { ...tokenInfo, networkId }
+      output[getTokenId(tokenInfo, networkId)] = { ...tokenInfo, networkId, tokenId: getTokenId(tokenInfo, networkId) }
     }
   }
   return output

--- a/src/tokens-info.ts
+++ b/src/tokens-info.ts
@@ -1,4 +1,4 @@
-import { NetworkId, TokenInfoProcessed, TokenInfoJSON } from './types'
+import { NetworkId, TokenInfo, TokenInfoJSON } from './types'
 import CeloMainnetTokensInfo from './data/mainnet/celo-tokens-info.json'
 import CeloAlfajoresTokensInfo from './data/testnet/celo-alfajores-tokens-info.json'
 import EthereumMainnetTokensInfo from './data/mainnet/ethereum-tokens-info.json'
@@ -12,16 +12,16 @@ const networkIdToTokensInfo: Record<NetworkId, TokenInfoJSON[]> = {
 }
 
 export function getTokenId(
-  { isNative, address }: Partial<TokenInfoProcessed>,
+  { isNative, address }: Partial<TokenInfo>,
   networkId: NetworkId,
 ): string {
   return `${networkId}:${isNative ? 'native' : address}`
 }
 
 export function getTokensInfoByNetworkIds(networkIds: NetworkId[]): {
-  [tokenId: string]: TokenInfoProcessed
+  [tokenId: string]: TokenInfo
 } {
-  const output: { [tokenId: string]: TokenInfoProcessed } = {}
+  const output: { [tokenId: string]: TokenInfo } = {}
   for (const networkId of networkIds) {
     for (const tokenInfo of networkIdToTokensInfo[networkId]) {
       const tokenId = getTokenId(tokenInfo, networkId)

--- a/src/tokens-info.ts
+++ b/src/tokens-info.ts
@@ -4,13 +4,12 @@ import CeloAlfajoresTokensInfo from './data/testnet/celo-alfajores-tokens-info.j
 import EthereumMainnetTokensInfo from './data/mainnet/ethereum-tokens-info.json'
 import EthereumSepoliaTokensInfo from './data/testnet/ethereum-sepolia-tokens-info.json'
 
-const networkIdToTokensInfo: Record<NetworkId, TokenInfoJSON[]> =
-  {
-    [NetworkId['celo-mainnet']]: CeloMainnetTokensInfo,
-    [NetworkId['celo-alfajores']]: CeloAlfajoresTokensInfo,
-    [NetworkId['ethereum-mainnet']]: EthereumMainnetTokensInfo,
-    [NetworkId['ethereum-sepolia']]: EthereumSepoliaTokensInfo,
-  }
+const networkIdToTokensInfo: Record<NetworkId, TokenInfoJSON[]> = {
+  [NetworkId['celo-mainnet']]: CeloMainnetTokensInfo,
+  [NetworkId['celo-alfajores']]: CeloAlfajoresTokensInfo,
+  [NetworkId['ethereum-mainnet']]: EthereumMainnetTokensInfo,
+  [NetworkId['ethereum-sepolia']]: EthereumSepoliaTokensInfo,
+}
 
 export function getTokenId(
   { isNative, address }: Partial<TokenInfoProcessed>,
@@ -25,7 +24,11 @@ export function getTokensInfoByNetworkIds(networkIds: NetworkId[]): {
   const output: { [tokenId: string]: TokenInfoProcessed } = {}
   for (const networkId of networkIds) {
     for (const tokenInfo of networkIdToTokensInfo[networkId]) {
-      output[getTokenId(tokenInfo, networkId)] = { ...tokenInfo, networkId, tokenId: getTokenId(tokenInfo, networkId) }
+      output[getTokenId(tokenInfo, networkId)] = {
+        ...tokenInfo,
+        networkId,
+        tokenId: getTokenId(tokenInfo, networkId),
+      }
     }
   }
   return output

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,11 +29,11 @@ export interface TokensInfoCFConfig {
   networkIds: NetworkId[]
 }
 
-export interface TokenInfo {
+// The token info type for the static data stored in the JSON files
+export interface TokenInfoJSON {
   name: string
   symbol: string
   decimals: number
-  networkId: NetworkId
   address?: string
   imageUrl?: string
   isNative?: boolean
@@ -41,6 +41,12 @@ export interface TokenInfo {
   pegTo?: string
   isSupercharged?: boolean
   bridge?: string
+}
+
+// The token info type after a small amount of processing which is used in the cloud function
+export interface TokenInfoProcessed extends TokenInfoJSON {
+  networkId: NetworkId
+  tokenId: string
 }
 
 export enum NetworkId {

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,7 @@ export interface TokenInfoJSON {
 }
 
 // The token info type after a small amount of processing which is used in the cloud function
-export interface TokenInfoProcessed extends TokenInfoJSON {
+export interface TokenInfo extends TokenInfoJSON {
   networkId: NetworkId
   tokenId: string
 }

--- a/src/utils/transforms.ts
+++ b/src/utils/transforms.ts
@@ -1,10 +1,10 @@
-import { TokenInfo } from '../types'
+import { TokenInfoJSON } from '../types'
 
-type CeloRTDBTokenInfo = Omit<TokenInfo, 'networkId' | 'isNative' | 'bridge'>
+type CeloRTDBTokenInfo = Omit<TokenInfoJSON, 'isNative' | 'bridge'>
 
 // Transforms the Celo tokens info data in this repo into the format used in the RTDB collection
 export function transformCeloTokensForRTDB(
-  celoTokensInfo: Omit<TokenInfo, 'networkId'>[],
+  celoTokensInfo: TokenInfoJSON[],
 ): Record<string, CeloRTDBTokenInfo> {
   return Object.fromEntries(
     celoTokensInfo.map((rawTokenInfo) => {


### PR DESCRIPTION
* adds tokenId field to the get-token-info cloud function
* refactors to have separate types/schemas for the JSON tokenInfo and the Processed tokenInfo

Per feedback on https://github.com/valora-inc/blockchain-api/pull/336#discussion_r1338234104