### PR TITLE
feat(token): enable eXOF usable as feeCurrency on alfajores

### DIFF
--- a/src/data/testnet/celo-alfajores-tokens-info.json
+++ b/src/data/testnet/celo-alfajores-tokens-info.json
@@ -254,6 +254,7 @@
     "address": "0xb0fa15e002516d0301884059c0aac0f0c72b019d",
     "decimals": 18,
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/eXOF.png",
+    "isCoreToken": true,
     "name": "ECO CFA",
     "symbol": "eXOF"
   }


### PR DESCRIPTION
eXOF is part of the listed fee currencies:

https://alfajores.celoscan.io/address/0xb8641365dbe943bc2fb6977e6fbc1630ef47db5a#readProxyContract

<img width="823" alt="Screenshot 2023-10-17 at 14 05 02" src="https://github.com/valora-inc/address-metadata/assets/57791/6a3cdbb0-0d78-4768-ae99-356ab872c1f2">

Enabling only on Alfajores for testing. Then we can do the same on mainnet if everything works.

Note: I checked it supports [transferWithComment](https://explorer.celo.org/alfajores/address/0xB0FA15e002516d0301884059c0aaC0F0C72b019D/write-proxy#address-tabs).

But I saw [G$](https://explorer.celo.org/alfajores/token/0x03d3daB843e6c03b3d271eff9178e6A96c28D25f/token-transfers) is also listed as a feeCurrency (only on alfajores), but doesn't support [transferWithComment](https://explorer.celo.org/alfajores/address/0x03d3daB843e6c03b3d271eff9178e6A96c28D25f/write-proxy#address-tabs) which means we should split isCoreToken into 2 things: `canTransferWithComment` and `isFeeCurrency`
