### PR TITLE
Update address of Sepolia USDC

### DIFF
--- a/src/data/testnet/ethereum-sepolia-tokens-info.json
+++ b/src/data/testnet/ethereum-sepolia-tokens-info.json
@@ -12,7 +12,7 @@
     "name": "USD Coin",
     "symbol": "USDC",
     "decimals": 6,
-    "address": "0x8267cf9254734c6eb452a7bb9aaf97b392258b21",
+    "address": "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8",
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/USDC.png",
     "isStableCoin": true,
     "infoUrl": "https://www.coingecko.com/en/coins/usdc"


### PR DESCRIPTION
I'm currently working on testing non-native ERC20 sends from the wallet, and was able to receive some Sepolia USDC from [this faucet](https://staging.aave.com/faucet/) hosted by Aave. (As a sidenote, this faucet seems to give a variety of useful testnet ERC20 tokens in large amounts -- good to use for testing purposes. In conjunction with Alchemy's [Sepolia ETH faucet](https://sepoliafaucet.com/), these should both cover a lot of our test cases.)

The USDC that I was given from this faucet is actually the contract [here](https://sepolia.etherscan.io/token/0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8). Compare the frequency of events on this contract to the one that Sepolia USDC is [currently set to](https://sepolia.etherscan.io/address/0x8267cf9254734c6eb452a7bb9aaf97b392258b21). Updating the address here since we have a reliable source for this test USDC at the new address, and it won't show up in-app otherwise.