### PR TITLE
chore: disable CRV swapping

### DIFF
--- a/src/data/mainnet/celo-tokens-info.json
+++ b/src/data/mainnet/celo-tokens-info.json
@@ -46,7 +46,7 @@
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/CRV.png",
     "name": "Curve DAO Token",
     "symbol": "CRV",
-    "minimumAppVersionToSwap": "1.68.0"
+    "isSwappable": false
   },
   {
     "address": "0x122013fd7df1c6f636a5bb8f03108e876548b455",


### PR DESCRIPTION
...was impacted by the Multichain hack, so let's prevent people from swapping into CRV. (There's also very few txs total on CELO over the last 100 days).