### PR TITLE
feat: populate multiple chains in big query tokenInfo table

### DIFF
--- a/scripts/update-bq.ts
+++ b/scripts/update-bq.ts
@@ -14,7 +14,6 @@ const fieldsToKeep = [
   'decimals',
   'name',
   'symbol',
-  'isNative',
   'tokenId',
   'networkId',
 ] as const

--- a/scripts/update-bq.ts
+++ b/scripts/update-bq.ts
@@ -25,7 +25,7 @@ const tokensInfo = getTokensInfoByNetworkIds([
 
 const rows = Object.entries(tokensInfo).map(([_, tokenInfo]) => {
   const row: Record<string, string | number | boolean | null> = {}
-  fieldsToKeep.forEach((field) => (row[field] = tokenInfo[field] || null))
+  fieldsToKeep.forEach((field) => (row[field] = tokenInfo[field] ?? null))
   return row
 })
 

--- a/scripts/update-bq.ts
+++ b/scripts/update-bq.ts
@@ -1,20 +1,32 @@
 /* eslint-disable no-console */
 
 import { BigQuery } from '@google-cloud/bigquery'
-import jsonData from '../src/data/mainnet/celo-tokens-info.json'
+import { NetworkId } from '../src/types'
+import { getTokensInfoByNetworkIds } from '../src/tokens-info'
 
 const bigquery = new BigQuery()
 
 const projectId = 'celo-mobile-mainnet' // we don't index testnet data
 const datasetId = 'address_metadata'
 const tableId = 'tokens_info'
-const fieldsToKeep = ['address', 'decimals', 'name', 'symbol'] as const
+const fieldsToKeep = [
+  'address',
+  'decimals',
+  'name',
+  'symbol',
+  'isNative',
+  'tokenId',
+  'networkId',
+] as const
 
-const rows = jsonData.map((entry) => {
-  const row: Record<string, string | number> = {}
-  fieldsToKeep.forEach((field) => {
-    row[field] = entry[field]
-  })
+const tokensInfo = getTokensInfoByNetworkIds([
+  NetworkId['celo-mainnet'],
+  NetworkId['ethereum-mainnet'],
+])
+
+const rows = Object.entries(tokensInfo).map(([_, tokenInfo]) => {
+  const row: Record<string, string | number | boolean | null> = {}
+  fieldsToKeep.forEach((field) => (row[field] = tokenInfo[field] || null))
   return row
 })
 


### PR DESCRIPTION
### Description

Adds Ethereum tokens from to the `address_metadata.tokens_info` in Big Query. The table should be edited to include the following nullable fields: `tokenId` and `networkId`.

### Related Issues
ACT-953