### PR TITLE
chore: make ETH cash-in eligible

### DIFF
--- a/src/data/mainnet/ethereum-tokens-info.json
+++ b/src/data/mainnet/ethereum-tokens-info.json
@@ -7,7 +7,8 @@
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/ETH.png",
     "showZeroBalance": true,
     "infoUrl": "https://www.coingecko.com/en/coins/ethereum",
-    "minimumAppVersionToSwap": "1.72.0"
+    "minimumAppVersionToSwap": "1.72.0",
+    "isCashInEligible": true
   },
   {
     "name": "USD Coin",

--- a/src/data/testnet/ethereum-sepolia-tokens-info.json
+++ b/src/data/testnet/ethereum-sepolia-tokens-info.json
@@ -6,7 +6,8 @@
     "isNative": true,
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/ETH.png",
     "showZeroBalance": true,
-    "infoUrl": "https://www.coingecko.com/en/coins/ethereum"
+    "infoUrl": "https://www.coingecko.com/en/coins/ethereum",
+    "isCashInEligible": true
   },
   {
     "name": "USD Coin",


### PR DESCRIPTION
ETH was not marked as `cashInEligible` so was not showing up on the new CICO token bottom sheet, now it should.