### PR TITLE
fix: fix undefined properties issue

### DIFF
--- a/src/utils/transforms.test.ts
+++ b/src/utils/transforms.test.ts
@@ -50,4 +50,34 @@ describe('transforms', () => {
     expect(transformData[address1].isCoreToken).toBeFalsy()
     expect(transformData[address2].isCoreToken).toBeTruthy()
   })
+
+  it('should not have undefined properties', () => {
+    const address1 = '0x00400fcbf0816bebb94654259de7273f4a05c762'
+    const address2 = '0x452ef5a4bd00796e62e5e5758548e0da6e8ccdf3'
+    const mockTokensInfo = [
+      {
+        address: address1,
+        name: 'Test Token 1',
+        symbol: 'TT1',
+        decimals: 18,
+      },
+      {
+        address: address2,
+        name: 'Test Token 2',
+        symbol: 'TT2',
+        decimals: 18,
+        isFeeCurrency: true,
+      },
+    ]
+
+    const transformData = transformCeloTokensForRTDB(mockTokensInfo)
+
+    for (const address of Object.keys(transformData)) {
+      expect(
+        Object.values(transformData[address]).every(isNotUndefined),
+      ).toBeTruthy()
+    }
+  })
 })
+
+const isNotUndefined = (value: any) => value !== undefined

--- a/src/utils/transforms.ts
+++ b/src/utils/transforms.ts
@@ -11,7 +11,15 @@ export function transformCeloTokensForRTDB(
       const { address, isNative, bridge, name: rawName, ...rest } = rawTokenInfo
       const name = bridge ? `${rawName} (${bridge})` : rawName
       const isCoreToken = rawTokenInfo.isFeeCurrency // for backwards compatibility. `isCoreToken` is deprecated
-      return [address, { address, name, ...rest, isCoreToken }]
+      return [
+        address,
+        {
+          address,
+          name,
+          ...rest,
+          ...(isCoreToken !== undefined ? { isCoreToken } : null),
+        },
+      ]
     }),
   )
 }


### PR DESCRIPTION
Fixing an issue introduced in https://github.com/valora-inc/address-metadata/pull/306: tokens not having `isFeeCurrency` property programmatically received `isCoreToken: undefined` property which caused RTDB update to fail.

### Test plan

Updated unit tests

### Related issues

Related to RET-899