### PR TITLE
chore(cash-in): add USDT and USDC as cash-in tokens

### DIFF
--- a/src/data/mainnet/ethereum-tokens-info.json
+++ b/src/data/mainnet/ethereum-tokens-info.json
@@ -27,7 +27,8 @@
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/USDC.png",
     "isStableCoin": true,
     "infoUrl": "https://www.coingecko.com/en/coins/usdc",
-    "minimumAppVersionToSwap": "1.72.0"
+    "minimumAppVersionToSwap": "1.72.0",
+    "isCashInEligible": true
   },
   {
     "name": "Tether USD",
@@ -36,7 +37,9 @@
     "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/USDT.png",
     "infoUrl": "https://www.coingecko.com/en/coins/tether",
-    "minimumAppVersionToSwap": "1.72.0"
+    "minimumAppVersionToSwap": "1.72.0",
+    "isStableCoin": true,
+    "isCashInEligible": true
   },
   {
     "name": "Binance",

--- a/src/data/testnet/ethereum-sepolia-tokens-info.json
+++ b/src/data/testnet/ethereum-sepolia-tokens-info.json
@@ -16,6 +16,18 @@
     "address": "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8",
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/USDC.png",
     "isStableCoin": true,
-    "infoUrl": "https://www.coingecko.com/en/coins/usdc"
+    "infoUrl": "https://www.coingecko.com/en/coins/usdc",
+    "isCashInEligible": true
+  },
+  {
+    "name": "Tether USD",
+    "symbol": "USDT",
+    "decimals": 6,
+    "address": "0x7169d38820dfd117c3fa1f22a697dba58d90ba06",
+    "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/USDT.png",
+    "infoUrl": "https://www.coingecko.com/en/coins/tether",
+    "minimumAppVersionToSwap": "1.72.0",
+    "isStableCoin": true,
+    "isCashInEligible": true
   }
 ]


### PR DESCRIPTION
We have added support for the following:

USDC: Simplex, Ramp, Moonpay, CBPay, Bitmama, Fonbnk
USDT: Simplex, Ramp, Moonpay, CBPay, Bitmama

https://linear.app/valora/issue/ACT-1015/update-address-metadata-for-usdcandt-cico

Will test on Testflight