### PR TITLE
feat(arbitrum): add arbitrum-one, arbitrum-sepolia

### DIFF
--- a/src/data/mainnet/arbitrum-one-tokens-info.json
+++ b/src/data/mainnet/arbitrum-one-tokens-info.json
@@ -1,0 +1,33 @@
+[
+  {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18,
+    "isNative": true,
+    "isL2Native": true,
+    "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/ETH.png",
+    "showZeroBalance": true,
+    "infoUrl": "https://www.coingecko.com/en/coins/ethereum"
+  },
+  {
+    "address": "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+    "decimals": 6,
+    "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/USDC.png",
+    "name": "USD Coin",
+    "symbol": "USDC"
+  },
+  {
+    "address": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
+    "decimals": 6,
+    "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/USDT.png",
+    "name": "Tether USD",
+    "symbol": "USDT"
+  },
+  {
+    "address": "0x912ce59144191c1204e64559fe8253a0e49e6548",
+    "name": "Arbitrum",
+    "symbol": "ARB",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/ARB.png"
+  }
+]

--- a/src/data/testnet/arbitrum-sepolia-tokens-info.json
+++ b/src/data/testnet/arbitrum-sepolia-tokens-info.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18,
+    "isNative": true,
+    "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/ETH.png",
+    "showZeroBalance": true,
+    "infoUrl": "https://www.coingecko.com/en/coins/ethereum"
+  }
+]

--- a/src/data/testnet/arbitrum-sepolia-tokens-info.json
+++ b/src/data/testnet/arbitrum-sepolia-tokens-info.json
@@ -4,6 +4,7 @@
     "symbol": "ETH",
     "decimals": 18,
     "isNative": true,
+    "isL2Native": true,
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/ETH.png",
     "showZeroBalance": true,
     "infoUrl": "https://www.coingecko.com/en/coins/ethereum"

--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -1,5 +1,8 @@
 import { getCeloRTDBMetadata } from './index'
-import { getTokensInfoByNetworkIds } from './tokens-info'
+import {
+  getTokensInfoByNetworkIds,
+  networkIdToNetworkIconUrl,
+} from './tokens-info'
 import { NetworkId, TokenInfo } from './types'
 import {
   TokenInfoSchemaProcessed,
@@ -187,11 +190,13 @@ describe('Schema validation', () => {
         }
       }
     })
-    it('still shows network icon if native token is L2', () => {
-      for (const tokenInfo of tokensInfo) {
-        expect(
-          tokenInfo.isL2Native ? tokenInfo.networkIconUrl : 'not L2 native',
-        ).toBeDefined()
+    it('shows correct network icon if native token is L2', () => {
+      for (const tokenInfo of tokensInfo.filter(
+        ({ isL2Native }) => isL2Native,
+      )) {
+        expect(tokenInfo.networkIconUrl).toEqual(
+          networkIdToNetworkIconUrl[tokenInfo.networkId],
+        )
       }
     })
     it('sets deprecated property `isCoreToken` equal to `isFeeCurrency`', () => {

--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -1,8 +1,5 @@
 import { getCeloRTDBMetadata } from './index'
-import {
-  getTokensInfoByNetworkIds,
-  networkIdToNetworkIconUrl,
-} from './tokens-info'
+import { getTokensInfoByNetworkIds } from './tokens-info'
 import { NetworkId, TokenInfo } from './types'
 import {
   TokenInfoSchemaProcessed,
@@ -16,6 +13,15 @@ function validateWithSchema(value: any, schema: Joi.Schema) {
     convert: false, // prevents casting values to the required types (e.g. a string to a number)
     abortEarly: false, // returns all errors at once
   })
+}
+
+const networkIdToIsL2: Record<NetworkId, boolean> = {
+  [NetworkId['celo-mainnet']]: false,
+  [NetworkId['celo-alfajores']]: false,
+  [NetworkId['ethereum-mainnet']]: false,
+  [NetworkId['ethereum-sepolia']]: false,
+  [NetworkId['arbitrum-one']]: true,
+  [NetworkId['arbitrum-sepolia']]: true,
 }
 
 describe('Schema validation', () => {
@@ -190,15 +196,14 @@ describe('Schema validation', () => {
         }
       }
     })
-    it('shows correct network icon if native token is L2', () => {
-      for (const tokenInfo of tokensInfo.filter(
-        ({ isL2Native }) => isL2Native,
-      )) {
-        expect(tokenInfo.networkIconUrl).toEqual(
-          networkIdToNetworkIconUrl[tokenInfo.networkId],
+    it('L2 networks have all native tokens marked as L2', () => {
+      for (const { networkId, isL2Native, isNative } of tokensInfo) {
+        expect(!!isL2Native).toEqual(
+          !!(isNative && networkIdToIsL2[networkId as NetworkId]),
         )
       }
     })
+
     it('sets deprecated property `isCoreToken` equal to `isFeeCurrency`', () => {
       for (const tokenInfo of tokensInfo) {
         expect(tokenInfo.isCoreToken).toEqual(tokenInfo.isFeeCurrency)

--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -187,6 +187,13 @@ describe('Schema validation', () => {
         }
       }
     })
+    it('still shows network icon if native token is L2', () => {
+      for (const tokenInfo of tokensInfo) {
+        expect(
+          tokenInfo.isL2Native ? tokenInfo.networkIconUrl : 'not L2 native',
+        ).toBeDefined()
+      }
+    })
     it('sets deprecated property `isCoreToken` equal to `isFeeCurrency`', () => {
       for (const tokenInfo of tokensInfo) {
         expect(tokenInfo.isCoreToken).toEqual(tokenInfo.isFeeCurrency)

--- a/src/schemas/tokens-info.ts
+++ b/src/schemas/tokens-info.ts
@@ -56,6 +56,7 @@ const BaseTokenInfoSchema = Joi.object({
     .pattern(/^\d+\.\d+\.\d+$/)
     .custom(checkMinVersion, 'has a valid version'),
   isNative: Joi.boolean(),
+  isL2Native: Joi.boolean(),
   infoUrl: Joi.string()
     .uri()
     .pattern(/^https:\/\/www.coingecko.com\/en\/coins/),
@@ -73,7 +74,11 @@ const ProcessedTokenInfoSchema = BaseTokenInfoSchema.concat(
     tokenId: Joi.string().required(),
     networkIconUrl: Joi.alternatives().conditional('isNative', {
       is: true,
-      then: Joi.forbidden(),
+      then: Joi.alternatives().conditional('isL2Native', {
+        is: true,
+        then: imageUrlSchema.required(),
+        otherwise: Joi.forbidden(),
+      }),
       otherwise: imageUrlSchema.required(),
     }),
   }),

--- a/src/tokens-info.ts
+++ b/src/tokens-info.ts
@@ -15,7 +15,7 @@ const networkIdToTokensInfo: Record<NetworkId, TokenInfoJSON[]> = {
   [NetworkId['arbitrum-sepolia']]: ArbitrumSepoliaTokensInfo,
 }
 
-export const networkIdToNetworkIconUrl: Record<NetworkId, string> = {
+const networkIdToNetworkIconUrl: Record<NetworkId, string> = {
   [NetworkId['ethereum-mainnet']]:
     'https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/ETH.png',
   [NetworkId['ethereum-sepolia']]:

--- a/src/tokens-info.ts
+++ b/src/tokens-info.ts
@@ -3,12 +3,16 @@ import CeloMainnetTokensInfo from './data/mainnet/celo-tokens-info.json'
 import CeloAlfajoresTokensInfo from './data/testnet/celo-alfajores-tokens-info.json'
 import EthereumMainnetTokensInfo from './data/mainnet/ethereum-tokens-info.json'
 import EthereumSepoliaTokensInfo from './data/testnet/ethereum-sepolia-tokens-info.json'
+import ArbitrumOneTokensInfo from './data/mainnet/arbitrum-one-tokens-info.json'
+import ArbitrumSepoliaTokensInfo from './data/testnet/arbitrum-sepolia-tokens-info.json'
 
 const networkIdToTokensInfo: Record<NetworkId, TokenInfoJSON[]> = {
   [NetworkId['celo-mainnet']]: CeloMainnetTokensInfo,
   [NetworkId['celo-alfajores']]: CeloAlfajoresTokensInfo,
   [NetworkId['ethereum-mainnet']]: EthereumMainnetTokensInfo,
   [NetworkId['ethereum-sepolia']]: EthereumSepoliaTokensInfo,
+  [NetworkId['arbitrum-one']]: ArbitrumOneTokensInfo,
+  [NetworkId['arbitrum-sepolia']]: ArbitrumSepoliaTokensInfo,
 }
 
 export function getTokenId(
@@ -32,7 +36,10 @@ export function getTokensInfoByNetworkIds(networkIds: NetworkId[]): {
         ...tokenInfo,
         networkId,
         tokenId,
-        networkIconUrl: tokenInfo.isNative ? undefined : nativeImageUrl,
+        networkIconUrl:
+          tokenInfo.isNative && !tokenInfo.isL2Native
+            ? undefined
+            : nativeImageUrl,
         isCoreToken: tokenInfo.isFeeCurrency, // for backwards compatibility. `isCoreToken` is deprecated
       }
     }

--- a/src/tokens-info.ts
+++ b/src/tokens-info.ts
@@ -15,6 +15,21 @@ const networkIdToTokensInfo: Record<NetworkId, TokenInfoJSON[]> = {
   [NetworkId['arbitrum-sepolia']]: ArbitrumSepoliaTokensInfo,
 }
 
+export const networkIdToNetworkIconUrl: Record<NetworkId, string> = {
+  [NetworkId['ethereum-mainnet']]:
+    'https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/ETH.png',
+  [NetworkId['ethereum-sepolia']]:
+    'https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/ETH.png',
+  [NetworkId['celo-mainnet']]:
+    'https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/CELO.png',
+  [NetworkId['celo-alfajores']]:
+    'https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/CELO.png',
+  [NetworkId['arbitrum-one']]:
+    'https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/ARB.png',
+  [NetworkId['arbitrum-sepolia']]:
+    'https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/ARB.png',
+}
+
 export function getTokenId(
   { isNative, address }: Partial<TokenInfo>,
   networkId: NetworkId,
@@ -27,9 +42,7 @@ export function getTokensInfoByNetworkIds(networkIds: NetworkId[]): {
 } {
   const output: { [tokenId: string]: TokenInfo } = {}
   for (const networkId of networkIds) {
-    const nativeImageUrl = networkIdToTokensInfo[networkId].find(
-      (tokenInfo) => tokenInfo.isNative,
-    )?.imageUrl
+    const networkIconUrl = networkIdToNetworkIconUrl[networkId]
     for (const tokenInfo of networkIdToTokensInfo[networkId]) {
       const tokenId = getTokenId(tokenInfo, networkId)
       output[tokenId] = {
@@ -39,7 +52,7 @@ export function getTokensInfoByNetworkIds(networkIds: NetworkId[]): {
         networkIconUrl:
           tokenInfo.isNative && !tokenInfo.isL2Native
             ? undefined
-            : nativeImageUrl,
+            : networkIconUrl,
         isCoreToken: tokenInfo.isFeeCurrency, // for backwards compatibility. `isCoreToken` is deprecated
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface TokenInfoJSON {
   address?: string
   imageUrl?: string
   isNative?: boolean
+  isL2Native?: boolean
   isCoreToken?: boolean
   isFeeCurrency?: boolean
   canTransferWithComment?: boolean
@@ -62,6 +63,8 @@ export enum NetworkId {
   ['celo-alfajores'] = 'celo-alfajores',
   ['ethereum-mainnet'] = 'ethereum-mainnet',
   ['ethereum-sepolia'] = 'ethereum-sepolia',
+  ['arbitrum-one'] = 'arbitrum-one',
+  ['arbitrum-sepolia'] = 'arbitrum-sepolia',
 }
 
 export type Environment = 'mainnet' | 'testnet'

--- a/src/utils/transforms.ts
+++ b/src/utils/transforms.ts
@@ -1,6 +1,9 @@
 import { TokenInfoJSON } from '../types'
 
-type CeloRTDBTokenInfo = Omit<TokenInfoJSON, 'isNative' | 'bridge'>
+type CeloRTDBTokenInfo = Omit<
+  TokenInfoJSON,
+  'isNative' | 'bridge' | 'isL2Native'
+>
 
 // Transforms the Celo tokens info data in this repo into the format used in the RTDB collection
 export function transformCeloTokensForRTDB(
@@ -8,7 +11,14 @@ export function transformCeloTokensForRTDB(
 ): Record<string, CeloRTDBTokenInfo> {
   return Object.fromEntries(
     celoTokensInfo.map((rawTokenInfo) => {
-      const { address, isNative, bridge, name: rawName, ...rest } = rawTokenInfo
+      const {
+        address,
+        isNative,
+        bridge,
+        isL2Native,
+        name: rawName,
+        ...rest
+      } = rawTokenInfo
       const name = bridge ? `${rawName} (${bridge})` : rawName
       const isCoreToken = rawTokenInfo.isFeeCurrency // for backwards compatibility. `isCoreToken` is deprecated
       return [


### PR DESCRIPTION
and require network icon URLs for L2 native tokens, and stop using the native token as the network icon (for arbitrum this doesn't work since the native token is ETH, but the network icon should be the same as ARB)