### PR TITLE
fix: ensure `isFeeCurrency` is `false` or not set when `feeCurrencyAdapterAddress` is set

### DIFF
--- a/src/data/testnet/celo-alfajores-tokens-info.json
+++ b/src/data/testnet/celo-alfajores-tokens-info.json
@@ -266,7 +266,7 @@
   {
     "address": "0x780c1551c2be3ea3b1f8b1e4cedc9c3ce40da24e",
     "decimals": 6,
-    "isFeeCurrency": true,
+    "isFeeCurrency": false,
     "feeCurrencyAdapterAddress": "0xc9cce1e51f1393ce39eb722e3e59ede6fabf89fd",
     "feeCurrencyAdapterDecimals": 18,
     "canTransferWithComment": false,

--- a/src/schemas/tokens-info.ts
+++ b/src/schemas/tokens-info.ts
@@ -69,10 +69,10 @@ const BaseTokenInfoSchema = Joi.object({
 })
   // Ensure `isFeeCurrency` is present when `isCoreToken` (deprecated) is present.
   .with('isCoreToken', 'isFeeCurrency')
-  // Ensure `isFeeCurrency` is true and `feeCurrencyAdapterDecimals` is present when `feeCurrencyAdapterAddress` is set.
+  // Ensure `isFeeCurrency` is false (or not set) and `feeCurrencyAdapterDecimals` is present when `feeCurrencyAdapterAddress` is set.
   .when(Joi.object({ feeCurrencyAdapterAddress: Joi.exist() }).unknown(), {
     then: Joi.object({
-      isFeeCurrency: Joi.valid(true),
+      isFeeCurrency: Joi.valid(false),
       feeCurrencyAdapterDecimals: Joi.required(),
     }),
   })


### PR DESCRIPTION
When an adapter is needed, the token address can't be used directly as a fee currency.
In order to be backward compatible, we must leave `isFeeCurrency: false` or not set it.

See Slack [thread](https://valora-app.slack.com/archives/C029Z1QMD7B/p1707907378255969?thread_ts=1707835925.846589&cid=C029Z1QMD7B) for context.

Fixes RET-1009