### PR TITLE
chore: update STBLTEST adapter address

### DIFF
--- a/src/data/testnet/celo-alfajores-tokens-info.json
+++ b/src/data/testnet/celo-alfajores-tokens-info.json
@@ -267,7 +267,7 @@
     "address": "0x780c1551c2be3ea3b1f8b1e4cedc9c3ce40da24e",
     "decimals": 6,
     "isFeeCurrency": false,
-    "feeCurrencyAdapterAddress": "0xc9cce1e51f1393ce39eb722e3e59ede6fabf89fd",
+    "feeCurrencyAdapterAddress": "0xdb93874fe111f5a87acc11ff09ee9450ac6509ae",
     "feeCurrencyAdapterDecimals": 18,
     "canTransferWithComment": false,
     "name": "Stable Test",


### PR DESCRIPTION
This is the latest adapter to use which works: https://alfajores.celoscan.io/tx/0x22613488f35616f1db2fc2cbd8d0b2227b1568c63a31e8ccb88f6a828acf3b04