### PR TITLE
Add Arbitrum and Optimism to tracked tokens in address_metadata.tokens_info

### DIFF
--- a/scripts/update-bq.ts
+++ b/scripts/update-bq.ts
@@ -22,7 +22,7 @@ const tokensInfo = getTokensInfoByNetworkIds([
   NetworkId['celo-mainnet'],
   NetworkId['ethereum-mainnet'],
   NetworkId['arbitrum-one'],
-  NetworkId['op-mainnet']
+  NetworkId['op-mainnet'],
 ])
 
 const rows = Object.entries(tokensInfo).map(([_, tokenInfo]) => {

--- a/scripts/update-bq.ts
+++ b/scripts/update-bq.ts
@@ -21,6 +21,8 @@ const fieldsToKeep = [
 const tokensInfo = getTokensInfoByNetworkIds([
   NetworkId['celo-mainnet'],
   NetworkId['ethereum-mainnet'],
+  NetworkId['arbitrum-one'],
+  NetworkId['op-mainnet']
 ])
 
 const rows = Object.entries(tokensInfo).map(([_, tokenInfo]) => {


### PR DESCRIPTION
Adding the `NetworkId` for `arbitrum-one` and `op-mainnet` in order to import tokens for these two chains into the address_metadata.tokens_info table in BigQuery. We will then be able to use this table to filter on the tokens for those two chains when we pull transfers into `valora_user_transfers`.