### PR TITLE
chore: update ubeswap

### DIFF
--- a/src/data/mainnet/celo-tokens-info.json
+++ b/src/data/mainnet/celo-tokens-info.json
@@ -19,6 +19,15 @@
     "address": "0x00be915b9dcf56a3cbe739d9b9c202ca692409ec",
     "decimals": 18,
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/UBE.png",
+    "name": "Old Ubeswap",
+    "symbol": "old-UBE",
+    "isSwappable": true,
+    "infoUrl": "https://www.coingecko.com/en/coins/ubeswap"
+  },
+  {
+    "address": "0x71e26d0e519d14591b9de9a0fe9513a398101490",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/UBE.png",
     "name": "Ubeswap",
     "symbol": "UBE",
     "isSwappable": true,

--- a/src/data/testnet/celo-alfajores-tokens-info.json
+++ b/src/data/testnet/celo-alfajores-tokens-info.json
@@ -3,6 +3,14 @@
     "address": "0x00be915b9dcf56a3cbe739d9b9c202ca692409ec",
     "decimals": 18,
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/UBE.png",
+    "name": "Old Ubeswap",
+    "symbol": "old-UBE",
+    "infoUrl": "https://www.coingecko.com/en/coins/ubeswap"
+  },
+  {
+    "address": "0x71e26d0e519d14591b9de9a0fe9513a398101490",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/UBE.png",
     "name": "Ubeswap",
     "symbol": "UBE",
     "infoUrl": "https://www.coingecko.com/en/coins/ubeswap"


### PR DESCRIPTION
### Description

Ubeswap is moving to a new contract address: [info](https://app.ubeswap.org/#/claim-new-ube) & [slack thread request](https://valora-app.slack.com/archives/C029Z1QMD7B/p1711053443782269).


> New Tokenomics
Ubeswap has migrated to new token economics.
All token swaps made until April 15th 2024 will be made on a 1:1,5 basis. After this period, it will switch to 1:1. After 75% of the liquid tokens are swapped, 1 month will be provided for the remainder of the community to swap. Any tokens not swapped after this period will be burned.

### Testing
Used Ubeswaps conversation tool and verified the [transaction on CeloScan](https://celoscan.io/tx/0x154ff71d0bdacacdb16231e1cb18ff9405b6c49c8fb6314e095efdbaafda8165).