### PR TITLE
fix: use old ube address on alfajores

### DIFF
--- a/src/data/testnet/celo-alfajores-tokens-info.json
+++ b/src/data/testnet/celo-alfajores-tokens-info.json
@@ -8,7 +8,7 @@
     "infoUrl": "https://www.coingecko.com/en/coins/ubeswap"
   },
   {
-    "address": "0x71e26d0e519d14591b9de9a0fe9513a398101490",
+    "address": "0x00be915b9dcf56a3cbe739d9b9c202ca692409ec",
     "decimals": 18,
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/UBE.png",
     "name": "Ubeswap",


### PR DESCRIPTION
### Description

Follow up to #441 using the old address for UBE on Alfajores to fix an issue described in [this comment](https://github.com/valora-inc/address-metadata/pull/441#discussion_r1547441287).