### PR TITLE
chore: add minimum swap version for polygon tokens

### DIFF
--- a/src/data/mainnet/polygon-pos-tokens-info.json
+++ b/src/data/mainnet/polygon-pos-tokens-info.json
@@ -6,13 +6,15 @@
     "decimals": 18,
     "isNative": true,
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/MATIC.png",
-    "infoUrl": "https://www.coingecko.com/en/coins/polygon"
+    "infoUrl": "https://www.coingecko.com/en/coins/polygon",
+    "minimumAppVersionToSwap": "1.82.0"
   },
   {
     "name": "USDC",
     "symbol": "USDC",
     "decimals": 6,
     "address": "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
-    "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/USDC.png"
+    "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/USDC.png",
+    "minimumAppVersionToSwap": "1.82.0"
   }
 ]


### PR DESCRIPTION
### Description

Adds the minimum swap version for polygon tokens to enable swaps in the wallet.