### PR TITLE
fix: remove matic address with no approval method

### DIFF
--- a/src/data/mainnet/polygon-pos-tokens-info.json
+++ b/src/data/mainnet/polygon-pos-tokens-info.json
@@ -2,7 +2,6 @@
   {
     "name": "Matic Token",
     "symbol": "MATIC",
-    "address": "0x0000000000000000000000000000000000001010",
     "decimals": 18,
     "isNative": true,
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/MATIC.png",

--- a/src/data/testnet/polygon-pos-mumbai-tokens-info.json
+++ b/src/data/testnet/polygon-pos-mumbai-tokens-info.json
@@ -2,7 +2,6 @@
   {
     "name": "Matic Token",
     "symbol": "MATIC",
-    "address": "0x0000000000000000000000000000000000001010",
     "decimals": 18,
     "isNative": true,
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/MATIC.png",

--- a/src/schemas/tokens-info.ts
+++ b/src/schemas/tokens-info.ts
@@ -97,14 +97,15 @@ const getTokenInfoSchema = (base: Joi.ObjectSchema<any>) =>
   Joi.alternatives().try(
     Joi.object({
       // native tokens don't have an address except CELO and MATIC
+      // MATIC's contract doesn't have standard ERC-20 methods so we treat as native without address
       isNative: Joi.valid(true).required(),
-      symbol: Joi.string().invalid('CELO').invalid('MATIC').required(),
+      symbol: Joi.string().invalid('CELO').required(),
       address: Joi.forbidden(),
     }).concat(base),
     Joi.object({
       // CELO is native and has an address
       isNative: Joi.valid(true).required(),
-      symbol: Joi.valid('CELO').valid('MATIC').required(),
+      symbol: Joi.valid('CELO').required(),
       address: AddressSchema.required(),
     }).concat(base),
     Joi.object({


### PR DESCRIPTION
### Description

MATIC's contract doesn't have standard ERC-20 methods and it's causing issues with our swaps. As a solution I've removed the address to allow it to be treated similar to other native tokens such as ETH.


### Related Issues

ACT-1124