### PR TITLE
feat(multichain): Make polygon and base tokens cash-in eligible

### DIFF
--- a/src/data/mainnet/base-tokens-info.json
+++ b/src/data/mainnet/base-tokens-info.json
@@ -7,7 +7,8 @@
     "isL2Native": true,
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/ETH.png",
     "infoUrl": "https://www.coingecko.com/en/coins/ethereum",
-    "minimumAppVersionToSwap": "1.81.0"
+    "minimumAppVersionToSwap": "1.81.0",
+    "isCashInEligible": true
   },
   {
     "name": "USDC",
@@ -15,6 +16,7 @@
     "decimals": 6,
     "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/USDC.png",
-    "minimumAppVersionToSwap": "1.81.0"
+    "minimumAppVersionToSwap": "1.81.0",
+    "isCashInEligible": true
   }
 ]

--- a/src/data/mainnet/polygon-pos-tokens-info.json
+++ b/src/data/mainnet/polygon-pos-tokens-info.json
@@ -6,7 +6,8 @@
     "isNative": true,
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/MATIC.png",
     "infoUrl": "https://www.coingecko.com/en/coins/polygon",
-    "minimumAppVersionToSwap": "1.82.0"
+    "minimumAppVersionToSwap": "1.82.0",
+    "isCashInEligible": true
   },
   {
     "name": "USDC",
@@ -14,6 +15,7 @@
     "decimals": 6,
     "address": "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/USDC.png",
-    "minimumAppVersionToSwap": "1.82.0"
+    "minimumAppVersionToSwap": "1.82.0",
+    "isCashInEligible": true
   }
 ]


### PR DESCRIPTION
Make MATIC and USDC cash in eligible on polygon mainnet, ETH and USDC cash in eligible on base mainnet.