### PR TITLE
feat(bigquery): add polygon to tracked tokens

### DIFF
--- a/scripts/update-bq.ts
+++ b/scripts/update-bq.ts
@@ -23,6 +23,7 @@ const tokensInfo = getTokensInfoByNetworkIds([
   NetworkId['ethereum-mainnet'],
   NetworkId['arbitrum-one'],
   NetworkId['op-mainnet'],
+  NetworkId['polygon-pos-mainnet']
 ])
 
 const rows = Object.entries(tokensInfo).map(([_, tokenInfo]) => {

--- a/scripts/update-bq.ts
+++ b/scripts/update-bq.ts
@@ -23,7 +23,7 @@ const tokensInfo = getTokensInfoByNetworkIds([
   NetworkId['ethereum-mainnet'],
   NetworkId['arbitrum-one'],
   NetworkId['op-mainnet'],
-  NetworkId['polygon-pos-mainnet']
+  NetworkId['polygon-pos-mainnet'],
 ])
 
 const rows = Object.entries(tokensInfo).map(([_, tokenInfo]) => {


### PR DESCRIPTION
Adding the NetworkId for polygon-pos-mainnet in order to import tokens for polygon into the address_metadata.tokens_info table in BigQuery. We will then be able to use this table to filter on the tokens for polygon when we pull transfers into valora_user_transfers.