### PR TITLE
fix(tokens): use the right usdc on arb sepolia

### DIFF
--- a/src/data/testnet/arbitrum-sepolia-tokens-info.json
+++ b/src/data/testnet/arbitrum-sepolia-tokens-info.json
@@ -9,7 +9,7 @@
     "infoUrl": "https://www.coingecko.com/en/coins/ethereum"
   },
   {
-    "address": "0xf3c3351d6bd0098eeb33ca8f830faf2a141ea2e1",
+    "address": "0x75faf114eafb1bdbe2f0316df893fd58ce46aa4d",
     "decimals": 6,
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/USDC.png",
     "name": "USDC",


### PR DESCRIPTION
Took this from the Aave sepolia contract https://github.com/bgd-labs/aave-address-book/blob/8e1ffb3499fdcde5941cf03ae42547f68ce25cad/src/AaveV3ArbitrumSepolia.sol#L89