### PR TITLE
chore: add aave arbitrum sepolia usdc

### DIFF
--- a/src/data/testnet/arbitrum-sepolia-tokens-info.json
+++ b/src/data/testnet/arbitrum-sepolia-tokens-info.json
@@ -14,5 +14,13 @@
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/USDC.png",
     "name": "USDC",
     "symbol": "USDC"
+  },
+  {
+    "address": "0x460b97bd498e1157530aeb3086301d5225b91216",
+    "name": "Aave Arbitrum Sepolia USDC",
+    "symbol": "aArbSepUSDC",
+    "decimals": 6,
+    "pegTo": "0x75faf114eafb1bdbe2f0316df893fd58ce46aa4d",
+    "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/USDC.png"
   }
 ]


### PR DESCRIPTION
### Description 

Adds Aave Arbitrum Sepolia USDC - https://sepolia.arbiscan.io/token/0x460b97BD498E1157530AEb3086301d5225b91216.