### PR TITLE
chore: add new PACT token

### DIFF
--- a/src/data/mainnet/celo-tokens-info.json
+++ b/src/data/mainnet/celo-tokens-info.json
@@ -197,6 +197,15 @@
     "address": "0x46c9757c5497c5b1f2eb73ae79b6b67d119b0b58",
     "decimals": 18,
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/PACT.png",
+    "name": "Old impactMarket",
+    "symbol": "old-PACT",
+    "minimumAppVersionToSwap": "1.60.0",
+    "infoUrl": "https://www.coingecko.com/en/coins/impactmarket"
+  },
+  {
+    "address": "0x2b9018ceb303d540bbf08de8e7de64fddd63396c",
+    "decimals": 18,
+    "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/PACT.png",
     "name": "impactMarket",
     "symbol": "PACT",
     "minimumAppVersionToSwap": "1.60.0",


### PR DESCRIPTION
impactMarket is migrating to the new PACT token

listing it in the same way [it was done for UBE](https://github.com/valora-inc/address-metadata/blob/ba7fe596ee06b3cccfdce16bf64e8bf182eb93a3/src/data/mainnet/celo-tokens-info.json#L19-L35) (#441)

context: 
* https://valora-app.slack.com/archives/C02UAE4MGUF/p1718292393805179
* https://twitter.com/impactmarket/status/1800620301996236866
* https://app.ubeswap.org/#/claim-new-pact

