### PR TITLE
feat: improve speed of bulk token add script

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,9 @@ To add support for tokens on a new blockchain, you need to follow these steps:
 There may be times where we want to add many new tokens at once. An example of how to do this is in `scripts/add-erc20-tokens-coingecko.ts`. This script utilizes Coingecko to get a list of tokens by market cap, and adds them to the specified tokens info file. It also adds the token images to the assets folder.
 
 Note that there are some expectations for the image assets, they should be 256x256 .png files and ideally under 60 KB in size. The above script will print warnings if the images do not meet these requirements, and manual intervention will be required to fix them. For resizing files, an online tool like [Tiny png](https://tinypng.com/) can be used.
+
+As an example, you can run the following command from the project root to add the top 20 tokens on Coingecko for the Ethereum network:
+
+```bash
+yarn ts-node scripts/add-erc20-tokens-coingecko.ts --category-id ethereum-ecosystem --platform-id ethereum --viem-chain-id mainnet --number-of-results 20 --page-number 1 --tokens-info-file-path src/data/mainnet/ethereum-tokens-info.json --enable-swap true
+```


### PR DESCRIPTION
Previously we were making requests to coingecko for each token to get the token address, which results in some necessary sleeps to avoid rate limiting. This PR fetches all tokens upfront so we only need to make 2 requests to coingecko per chain, which makes the script run much faster. + also make new tokens swappable by default.