### PR TITLE
feat(addresses-extra-info): add a friendly name for axelar gas service

### DIFF
--- a/src/data/mainnet/addresses-extra-info.json
+++ b/src/data/mainnet/addresses-extra-info.json
@@ -260,5 +260,9 @@
   "0xb902224fb0fd2cd996febba0a569bba05aab9df6": {
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/addresses/gas-refund.png",
     "name": "Valora Gas Refund"
+  },
+  "0x2d5d7d31f671f86c782533cc367f14109a082712": {
+    "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/addresses/gas-refund.png",
+    "name": "Swap Fee Refund"
   }
 }


### PR DESCRIPTION
Axelar Gas Service address is used to refund excessive cross-chain gas fees.

The address `0x2d5d7d31f671f86c782533cc367f14109a082712` is the same across all supported networks (see `axelarContracts` in Squid API `/chains` return values: https://squidrouter.readme.io/reference/get_chains)

Example tx: https://celoscan.io/tx/0x0a460f22636d6b1714bb537d2e7a34b7fc6880513cdf9544d2490c52df440692

Context: https://valora-app.slack.com/archives/C0684TXDR3K/p1721937744043559?thread_ts=1721316010.808989&cid=C0684TXDR3K