### PR TITLE
chore: Mark cKES as stablecoin

### DIFF
--- a/src/data/mainnet/celo-tokens-info.json
+++ b/src/data/mainnet/celo-tokens-info.json
@@ -722,6 +722,7 @@
     "canTransferWithComment": true,
     "name": "Celo Kenyan Shilling",
     "isCashInEligible": true,
+    "isStableCoin": true,
     "minimumAppVersionToSwap": "1.68.0",
     "symbol": "cKES"
   },


### PR DESCRIPTION
cKES was not showing up for cash-in when filtering by stablecoins. This should fix.