### PR TITLE
fix(ccop): add additional details

### DIFF
--- a/src/data/mainnet/celo-tokens-info.json
+++ b/src/data/mainnet/celo-tokens-info.json
@@ -754,8 +754,11 @@
     "address": "0x8a567e2ae79ca692bd748ab832081c45de4041ea",
     "decimals": 18,
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/cCOP.png",
+    "isFeeCurrency": true,
+    "canTransferWithComment": true,
     "name": "Celo Colombian Peso",
     "isStableCoin": true,
+    "minimumAppVersionToSwap": "1.68.0",
     "symbol": "cCOP"
   }
 ]


### PR DESCRIPTION
### Description

Adds additional fields to  cCOP (Celo Colombian Peso):
- `isFeeCurrency: true` - this is a cStable.
- `canTransferWithComment: true` - same as above.
-  `minimumAppVersionToSwap: 1.68.0` - so that cCOP appears as an available swap to token.