### PR TITLE
chore(aave): Add maxSupportedVersion for valora for Aave Arbitrum USDCn

### DIFF
--- a/src/data/mainnet/arbitrum-one-tokens-info.json
+++ b/src/data/mainnet/arbitrum-one-tokens-info.json
@@ -50,7 +50,7 @@
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/USDC.png",
     "minimumAppVersionToSwap": "1.77.0",
     "maxSupportedVersion": {
-      "valora": "1.96.0"
+      "valora": "1.95.1"
     }
   },
   {

--- a/src/data/mainnet/arbitrum-one-tokens-info.json
+++ b/src/data/mainnet/arbitrum-one-tokens-info.json
@@ -48,7 +48,10 @@
     "decimals": 6,
     "pegTo": "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/USDC.png",
-    "minimumAppVersionToSwap": "1.77.0"
+    "minimumAppVersionToSwap": "1.77.0",
+    "maxSupportedVersion": {
+      "valora": "1.96.0"
+    }
   },
   {
     "address": "0x11cdb42b0eb46d95f990bedd4695a6e3fa034978",

--- a/src/schemas/tokens-info.ts
+++ b/src/schemas/tokens-info.ts
@@ -58,8 +58,7 @@ const BaseTokenInfoSchema = Joi.object({
     .pattern(/^\d+\.\d+\.\d+$/)
     .custom(checkMinVersion, 'has a valid version'),
   maxSupportedVersion: Joi.object({
-    valora: Joi.string()
-      .pattern(/^\d+\.\d+\.\d+$/)
+    valora: Joi.string().pattern(/^\d+\.\d+\.\d+$/),
   }),
   isNative: Joi.boolean(),
   isL2Native: Joi.boolean(),

--- a/src/schemas/tokens-info.ts
+++ b/src/schemas/tokens-info.ts
@@ -60,7 +60,6 @@ const BaseTokenInfoSchema = Joi.object({
   maxSupportedVersion: Joi.object({
     valora: Joi.string()
       .pattern(/^\d+\.\d+\.\d+$/)
-      .custom(checkMinVersion, 'has a valid version'),
   }),
   isNative: Joi.boolean(),
   isL2Native: Joi.boolean(),

--- a/src/schemas/tokens-info.ts
+++ b/src/schemas/tokens-info.ts
@@ -57,6 +57,11 @@ const BaseTokenInfoSchema = Joi.object({
   minimumAppVersionToSwap: Joi.string()
     .pattern(/^\d+\.\d+\.\d+$/)
     .custom(checkMinVersion, 'has a valid version'),
+  maxSupportedVersion: Joi.object({
+    valora: Joi.string()
+      .pattern(/^\d+\.\d+\.\d+$/)
+      .custom(checkMinVersion, 'has a valid version'),
+  }),
   isNative: Joi.boolean(),
   isL2Native: Joi.boolean(),
   infoUrl: Joi.string()


### PR DESCRIPTION
Part of [ACT-1404](https://linear.app/valora/issue/ACT-1404/dont-show-aave-pool-token-on-token-list-version-=196)