### PR TITLE
ci: remove alfajores deploy

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -41,8 +41,8 @@ jobs:
       - run: yarn test:ci
       # update:mixpanel does a dry run by default
       - run: yarn update:mixpanel
-  update-testnet:
-    name: Update Testnet (celo-mobile-alfajores) RTDB
+  update-mainnet:
+    name: Update Mainnet RTDB
     if: github.ref == 'refs/heads/main'
     needs:
       - lint
@@ -52,26 +52,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
-          project_id: celo-mobile-alfajores
-          credentials_json: ${{ secrets.ALFAJORES_SERVICE_ACCOUNT_KEY }}
-      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
-        with:
-          node-version: '20.19.5'
-          check-latest: true
-      - run: yarn
-      - run: yarn update:rtdb --project=testnet --database-url=https://celo-mobile-alfajores.firebaseio.com/
-  update-mainnet:
-    name: Update Mainnet RTDB
-    if: github.ref == 'refs/heads/main'
-    needs:
-      - update-testnet
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        with:
-          project_id: celo-mobile-alfajores
+          project_id: celo-mobile-mainnet
           credentials_json: ${{ secrets.MAINNET_SERVICE_ACCOUNT_KEY }}
       - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
@@ -123,42 +104,12 @@ jobs:
       - run: yarn update:mixpanel --update-tables
         env:
           MIXPANEL_CREDENTIALS: '${{ steps.secrets.outputs.mixpanel_credentials }}'
-  deploy-dev:
-    name: Deploy dev cloud function
-    if: github.ref == 'refs/heads/main'
-    needs:
-      - lint
-      - test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        with:
-          project_id: celo-mobile-alfajores
-          credentials_json: ${{ secrets.ALFAJORES_SERVICE_ACCOUNT_KEY }}
-      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
-        with:
-          install_components: 'beta'
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
-        with:
-          node-version: '20.19.5'
-          check-latest: true
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn
-      - run: yarn build
-      - run: yarn deploy:dev getTokensInfo
   deploy-prod:
     name: Deploy prod cloud function
     if: github.ref == 'refs/heads/main'
     needs:
       - lint
       - test
-      - deploy-dev
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/config-dev.yaml
+++ b/config-dev.yaml
@@ -1,2 +1,0 @@
-NETWORK_IDS: 'celo-alfajores,ethereum-sepolia,arbitrum-sepolia,op-sepolia,polygon-pos-amoy,base-sepolia'
-GCLOUD_PROJECT: 'celo-mobile-alfajores'

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "update:rtdb": "ts-node scripts/update-rtdb.ts",
     "update:bq": "ts-node scripts/update-bq.ts",
     "update:mixpanel": "ts-node scripts/update-mixpanel.ts",
-    "deploy:dev": "gcloud beta functions deploy --gen2 --region=us-central1 --concurrency=80 --cpu=1 --memory=256MB --project=celo-mobile-alfajores --runtime=nodejs20 --trigger-http --allow-unauthenticated --env-vars-file=config-dev.yaml",
     "deploy:prod": "gcloud beta functions deploy --gen2 --region=us-central1 --concurrency=80 --cpu=1 --memory=256MB --project=celo-mobile-mainnet --runtime=nodejs20 --trigger-http --allow-unauthenticated --env-vars-file=config-prod.yaml"
   },
   "prettier": "@valora/prettier-config",


### PR DESCRIPTION
## Summary                                                                                                                         

Remove all CI jobs targeting the `celo-mobile-alfajores` GCP project, which has been deleted and causes deploy failures.              

## Changes                                                                                                                            

- **Remove `update-testnet` job** — deployed to `celo-mobile-alfajores` RTDB which no longer exists.                                  
- **Remove `deploy-dev` job and `deploy:dev` script** — deployed the cloud function to the deleted alfajores project. Also deletes the now-unused `config-dev.yaml`.                                                                                                        
- **Fix `deploy-prod` job** — remove dependency on the deleted `deploy-dev` job.