### PR TITLE
fix: peg Celo USAT price to Celo USD₮

### DIFF
--- a/src/data/mainnet/celo-tokens-info.json
+++ b/src/data/mainnet/celo-tokens-info.json
@@ -720,6 +720,7 @@
     "decimals": 6,
     "address": "0xd2ab3c9a02dbbab236bfec45d1d755df4267f771",
     "imageUrl": "https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/USAT.png",
+    "pegTo": "0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e",
     "feeCurrencyAdapterAddress": "0x0357ee22278c922e1d36cfe6b899269b161880c4",
     "feeCurrencyAdapterDecimals": 18,
     "showZeroBalance": true,


### PR DESCRIPTION
## Problem

Tether America USD (USAT) on **Celo** (`0xd2ab3c9a02dbbab236bfec45d1d755df4267f771`) has no USD price: CoinGecko only indexes the Ethereum USAT contract, so `getTokensInfoWithPrices` returns no `priceUsd` for the Celo deployment. The app shows _Price Unavailable_ and a warning dialog before every swap involving it, while the Ethereum USAT prices fine.

## Fix

Add `pegTo` pointing at USD₮ on Celo (`0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e`), following the same approach used by other tokens that track an already-priced asset (mCUSD → cUSD, aArbUSDCn → USDC, …). Both are Tether-issued USD stablecoins, so the peg matches the Ethereum USAT market price within rounding.

## Testing

- `yarn test` passes (773/773) — schema accepts the entry
- Verified the resulting payload end-to-end against a local proxy patched the same way: the app shows a fiat value for Celo USAT and the warning disappears